### PR TITLE
Little design tweaks

### DIFF
--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -12,7 +12,8 @@ import {
   EuiHeaderLinks,
   EuiHeaderSection,
   EuiHeaderSectionItem,
-  EuiHeaderLogo
+  EuiHeaderLogo,
+  EuiText,
 } from '@elastic/eui';
 
 import { TableOfContents } from './table_of_contents';
@@ -147,7 +148,7 @@ export class App extends Component {
       <div>
         <EuiHeader>
           <EuiHeaderSection>
-            <EuiHeaderSectionItem>
+            <EuiHeaderSectionItem border="none">
               <EuiHeaderLogo href="#" aria-label="Go to elastic.co" iconType="emsApp" >Elastic Maps Service</EuiHeaderLogo>
             </EuiHeaderSectionItem>
           </EuiHeaderSection>
@@ -168,6 +169,7 @@ export class App extends Component {
               <EuiPageContent>
                 <EuiPageContentBody>
                   <LayerDetails layerConfig={this.state.selectedFileLayer} />
+                  <EuiSpacer size="l" />
                   <FeatureTable
                     ref={setFeatureTable}
                     jsonFeatures={this.state.jsonFeatures}
@@ -177,6 +179,10 @@ export class App extends Component {
                   />
                 </EuiPageContentBody>
               </EuiPageContent>
+              <EuiSpacer />
+              <EuiText size="xs" textAlign="center">
+                <p>Please submit any issues with this layer or suggestions for improving this layer in the <a href="https://github.com/elastic/kibana/issues/new" target="_blank">Kibana repo</a>.</p>
+              </EuiText>
             </div>
           </EuiPageBody>
         </EuiPage>

--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -154,7 +154,7 @@ export class App extends Component {
           </EuiHeaderSection>
           <EuiHeaderSection side="right">
             <EuiHeaderLinks>
-              <EuiHeaderLink>elastic.co</EuiHeaderLink>
+              <EuiHeaderLink href="//elastic.co">elastic.co</EuiHeaderLink>
             </EuiHeaderLinks>
           </EuiHeaderSection>
         </EuiHeader>

--- a/public/js/components/feature_table.js
+++ b/public/js/components/feature_table.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import {
   EuiButton,
   EuiInMemoryTable,
-  EuiText
 } from '@elastic/eui';
 
 
@@ -92,13 +91,9 @@ export class FeatureTable extends Component {
 
   _renderToolsRight() {
     return (
-      <EuiText>
-        <div>
-          <EuiButton href={this.props.config.url} target="_">
-            Download {this.props.config.format}
-          </EuiButton>
-        </div>
-      </EuiText>
+      <EuiButton href={this.props.config.url} target="_">
+        Download {this.props.config.format}
+      </EuiButton>
     );
   }
 
@@ -115,6 +110,7 @@ export class FeatureTable extends Component {
     }
 
     const rows = this._getRows();
+    console.table(rows);
     const columns = this._getColumns();
 
     const search = {
@@ -138,7 +134,6 @@ export class FeatureTable extends Component {
         search={search}
         pagination={pagination}
         sorting
-        hasActions
       />
     );
   }

--- a/public/js/components/feature_table.js
+++ b/public/js/components/feature_table.js
@@ -110,7 +110,6 @@ export class FeatureTable extends Component {
     }
 
     const rows = this._getRows();
-    console.table(rows);
     const columns = this._getColumns();
 
     const search = {

--- a/public/js/components/layer_details.js
+++ b/public/js/components/layer_details.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
 
 import {
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiText,
+  EuiTitle,
 } from '@elastic/eui';
 
 import MarkdownIt from 'markdown-it';
@@ -33,32 +32,12 @@ export class LayerDetails extends Component {
 
     return (
       <div>
-        <EuiFlexGroup wrap>
-          <EuiFlexItem>
-            <EuiText>
-              <dl>
-                <dt>Name</dt>
-                <dd>{this.props.layerConfig.name}</dd>
-              </dl>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText>
-              <dl>
-                <dt>Attribution</dt>
-                <dd dangerouslySetInnerHTML={{ __html: attributionsHtmlString }} className="attribution"/>
-              </dl>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText>
-              <dl>
-                <dt>Report</dt>
-                <dd>Please submit any issues with this layer or suggestions for improving this layer in the <a href="https://github.com/elastic/kibana/issues/new" target="_blank">Kibana repo</a>.</dd>
-              </dl>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <EuiTitle size="s">
+          <h2>{this.props.layerConfig.name}</h2>
+        </EuiTitle>
+        <EuiText size="s">
+          <span dangerouslySetInnerHTML={{ __html: attributionsHtmlString }} className="attribution"/>
+        </EuiText>
       </div>
     );
   }

--- a/public/js/components/map.js
+++ b/public/js/components/map.js
@@ -66,7 +66,7 @@ export class Map extends Component {
       }
       rows += `<dt>${key}</dt><dd>${feature.properties[key]}</dd>`;
     });
-    const html = `<div class="euiText"><dl>${rows}</dl></div>`;
+    const html = `<div class="euiText euiText--extraSmall"><dl class="eui-definitionListReverse">${rows}</dl></div>`;
 
     this._currentPopup = new mapboxgl.Popup();
     this._currentPopup.setLngLat(lngLat);

--- a/public/js/components/table_of_contents.js
+++ b/public/js/components/table_of_contents.js
@@ -12,17 +12,31 @@ export class TableOfContents extends Component {
     super(props);
     this.state = {
       selectedItemId: null,
-      selectedConfig: null
+      selectedConfig: null,
+      isSideNavOpenOnMobile: false,
     };
+
+    this.toggleSideNavOpenOnMobile = this.toggleSideNavOpenOnMobile.bind(this);
   }
 
   render() {
     const sidebarItems = this._getSidebarItems();
     return (
       <EuiPageSideBar>
-        <EuiSideNav items={sidebarItems} />
+        <EuiSideNav
+          items={sidebarItems}
+          mobileTitle="Layers"
+          toggleOpenOnMobile={this.toggleSideNavOpenOnMobile}
+          isOpenOnMobile={this.state.isSideNavOpenOnMobile}
+        />
       </EuiPageSideBar>
     );
+  }
+
+  toggleSideNavOpenOnMobile() {
+    this.setState({
+      isSideNavOpenOnMobile: !this.state.isSideNavOpenOnMobile,
+    });
   }
 
   _createItem(id, name, config, data = {}) {

--- a/public/style/main.css
+++ b/public/style/main.css
@@ -9,6 +9,7 @@ body {
     width: 100%;
 }
 
+
 .mainContent {
     width: 100%;
 }
@@ -18,24 +19,21 @@ body {
     height: 512px;
 }
 
-.banner {
-    width: 100%;
-    height: 100px;
-}
-
-.dl {
-    width: 200px;
-}
-
 .attribution  p {
     display: inline;
 }
 
-.download {
-    font-weight: bold;
+
+/* The following will need to be fixed in EUI too */
+.euiHeader {
+    position: relative;
+    z-index: 2000;
 }
 
+.euiHeaderLinks {
+    position: static;
+}
 
-.mapboxgl-popup-content dd {
-    margin-bottom: 0;
+.euiHeaderSectionItem:hover {
+    background: transparent;
 }


### PR DESCRIPTION
@thomasneirynck 

Here are the few things I did:

- Altered layer details to user a header and paragraph and moved the reporting section to below the table (since it doesn’t change per layer).
- Somewhat fixed some mobile layout stuff (a few things still need to be permanently fixed in EUI)
- Reduced text size of the tooltip content

### Suggestion

Since there is only one action per row (show on map) I would highly suggest moving this to an `onClick` event on the row itself. That will give more room for the actual table contents. It also may be a nice feature to auto-scroll back up to the map when they click a row in case their window is short and the map isn't in view.