### PR TITLE
Use production manifest as default

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,5 +1,5 @@
 {
-  "default": "staging",
+  "default": "production",
   "SUPPORTED_EMS": {
     "version": "v2",
     "manifest": {


### PR DESCRIPTION
Fixes #36

The staging manifest can be loaded by adding the `?manifest=staging` query string to the URL.