### PR TITLE
Update staging URL for EMS

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -3,7 +3,7 @@
   "SUPPORTED_EMS": {
     "version": "v2",
     "manifest": {
-      "staging": "https://staging-dot-catalogue-dot-elastic-layer.appspot.com/v2/manifest",
+      "staging": "https://catalogue-staging.maps.elastic.co/v2/manifest",
       "production": "https://catalogue.maps.elastic.co/v2/manifest"
     }
   }


### PR DESCRIPTION
With the recent change to ems-file-service, we've updated the URL for the staging manifest. The old URL should not be used anymore.

Once merged, you should be able to see the correct files in staging from http://maps.elastic.co/?manifest=staging#file/USA%20States. 