### PR TITLE
Update to work with EMS v6.6

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,10 +1,10 @@
 {
   "default": "production",
   "SUPPORTED_EMS": {
-    "version": "v2",
+    "version": "v6.6",
     "manifest": {
-      "staging": "https://catalogue-staging.maps.elastic.co/v2/manifest",
-      "production": "https://catalogue.maps.elastic.co/v2/manifest"
+      "staging": "https://catalogue-staging.maps.elastic.co/v6.6/manifest",
+      "production": "https://catalogue.maps.elastic.co/v6.6/manifest"
     }
   }
 }

--- a/public/js/components/feature_table.js
+++ b/public/js/components/feature_table.js
@@ -30,10 +30,11 @@ export class FeatureTable extends Component {
     filter = filter ? filter : '';
     const filterNormalized = filter.toLowerCase();
     const passes = [];
+    const fields = this.props.config.getFieldsInLanguage();
     for (let i = 0; i < this.props.jsonFeatures.features.length; i++) {
       const feature = this.props.jsonFeatures.features[i];
-      for (let j = 0; j < this.props.config.fields.length; j++) {
-        const field = this.props.config.fields[j];
+      for (let j = 0; j < fields.length; j++) {
+        const field = fields[j];
         const fieldValue = feature.properties[field.name];
         const stringifiedFieldValue = JSON.stringify(fieldValue);
         if (!stringifiedFieldValue) {
@@ -55,7 +56,7 @@ export class FeatureTable extends Component {
   }
 
   _getColumns() {
-    return this.props.config.fields.map(field => ({
+    return this.props.config.getFieldsInLanguage().map(field => ({
       field: field.name,
       name: `${field.description} (${field.name})`,
       sortable: true,
@@ -76,15 +77,16 @@ export class FeatureTable extends Component {
 
   _renderToolsRight() {
     let humanReadableFormat;
-    if (this.props.config.format === 'geojson') {
+    const format = this.props.config.getDefaultFormatType();
+    if (format === 'geojson') {
       humanReadableFormat = 'GeoJSON';
-    } else if (this.props.config.format === 'topojson') {
+    } else if (format === 'topojson') {
       humanReadableFormat = 'TopoJSON';
     } else {
-      humanReadableFormat = this.props.config.format;
+      humanReadableFormat = format;
     }
     return (
-      <EuiButton href={this.props.config.url} target="_">
+      <EuiButton href={this.props.config.getDefaultFormatUrl()} target="_">
         Download {humanReadableFormat}
       </EuiButton>
     );

--- a/public/js/components/layer_details.js
+++ b/public/js/components/layer_details.js
@@ -1,18 +1,11 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 
 import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
 
-import MarkdownIt from 'markdown-it';
-
-const markdownIt = new MarkdownIt({
-  html: false,
-  linkify: true,
-});
-
-export class LayerDetails extends Component {
+export class LayerDetails extends PureComponent {
   constructor(props) {
     super(props);
   }
@@ -21,19 +14,11 @@ export class LayerDetails extends Component {
     if (!this.props.layerConfig) {
       return null;
     }
-
-    const attributions = this.props.layerConfig.attribution.split('|');
-    const htmlAttributions = attributions.map((attribution) => {
-      attribution = attribution.trim();
-      const html = markdownIt.render(attribution);
-      return html.trim();
-    });
-    const attributionsHtmlString = htmlAttributions.join(', ');
-
+    const attributionsHtmlString = this.props.layerConfig.getHTMLAttribution();
     return (
       <div>
         <EuiTitle size="s">
-          <h2>{this.props.layerConfig.name}</h2>
+          <h2>{this.props.layerConfig.getDisplayName()}</h2>
         </EuiTitle>
         <EuiText size="s">
           <span dangerouslySetInnerHTML={{ __html: attributionsHtmlString }} className="attribution"/>

--- a/public/js/components/map.js
+++ b/public/js/components/map.js
@@ -29,7 +29,7 @@ export class Map extends Component {
         sources: {
           'raster-tiles': {
             type: 'raster',
-            tiles: [this.props.baseLayer.url],
+            tiles: [this.props.baseLayer.getUrlTemplate()],
             tileSize: 256,
             scheme: 'xyz',
           },

--- a/public/js/components/table_of_contents.js
+++ b/public/js/components/table_of_contents.js
@@ -39,7 +39,7 @@ export class TableOfContents extends Component {
     });
   }
 
-  _createItem(id, name, config, onClickHandler, data = {}) {
+  _createItem(id, name, onClickHandler, data = {}) {
     return Object.assign(data, {
       id,
       name,
@@ -60,16 +60,15 @@ export class TableOfContents extends Component {
   }
 
   _getSidebarItems() {
-    const fileItems = this.props.layers.file.manifest.layers.map((service) => {
-      const id = `file/${service.name}`;
-      const name = service.name;
+    const fileItems = this.props.layers.file.map((service) => {
+      const id = `file/${service.getId()}`;
+      const name = service.getDisplayName();
       return this._createItem(
         id,
         name,
-        service,
         () => this.selectItem(id, service));
     });
-    const files = this._createItem('file', 'Vector Layers', this.props.layers.file.meta, null, {
+    const files = this._createItem('file', 'Vector Layers', null, {
       icon: <EuiIcon type="vector" />,
       items: fileItems,
     });

--- a/public/js/ems_client.js
+++ b/public/js/ems_client.js
@@ -1,0 +1,205 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import MarkdownIt from 'markdown-it';
+import _ from 'lodash';
+import { modifyUrl } from './modify_url';
+import { TMSService } from './tms_service';
+import { FileLayer } from './file_layer';
+
+const extendUrl = (url, props) => (
+  modifyUrl(url, parsed => _.merge(parsed, props))
+);
+
+const markdownIt = new MarkdownIt({
+  html: false,
+  linkify: true
+});
+
+
+/**
+ *  Unescape a url template that was escaped by encodeURI() so leaflet
+ *  will be able to correctly locate the variables in the template
+ *  @param  {String} url
+ *  @return {String}
+ */
+const unescapeTemplateVars = url => {
+  const ENCODED_TEMPLATE_VARS_RE = /%7B(\w+?)%7D/g;
+  return url.replace(ENCODED_TEMPLATE_VARS_RE, (total, varName) => `{${varName}}`);
+};
+
+
+const DEFAULT_LANGUAGE = 'en';
+
+
+export class EMSClientV66 {
+
+
+  constructor({ manifestServiceUrl, htmlSanitizer, language }) {
+
+    this._queryParams = {
+    //   my_app_version: kbnVersion
+    };
+
+    this._sanitizer = htmlSanitizer ? htmlSanitizer : x => x;
+    this._manifestServiceUrl = manifestServiceUrl;
+    this._loadCatalogue = null;
+    this._loadFileLayers = null;
+    this._loadTMSServices = null;
+    // this._emsLandingPageUrl = landingPageUrl;
+    this._language = typeof language === 'string' ? language : DEFAULT_LANGUAGE;
+
+    this._invalidateSettings();
+
+  }
+
+
+  getValueInLanguage(i18nObject) {
+    if (!i18nObject) {
+      return '';
+    }
+    return i18nObject[this._language] ? i18nObject[this._language] : i18nObject[DEFAULT_LANGUAGE];
+  }
+
+  /**
+   * this internal method is overridden by the tests to simulate custom manifest.
+   */
+  async _getManifest(manifestUrl) {
+    const url = extendUrl(manifestUrl, { query: this._queryParams });
+    const result = await fetch(url);
+    return await result.json();
+  }
+
+
+  /**
+   * Add optional query-parameters to all requests
+   *
+   * @param additionalQueryParams
+   */
+  addQueryParams(additionalQueryParams) {
+    for (const key in additionalQueryParams) {
+      if (additionalQueryParams.hasOwnProperty(key)) {
+        if (additionalQueryParams[key] !== this._queryParams[key]) {
+          //changes detected.
+          this._queryParams = _.assign({}, this._queryParams, additionalQueryParams);
+          this._invalidateSettings();
+          break;
+        }
+      }
+    }
+  }
+
+  _invalidateSettings() {
+
+    this._loadCatalogue = _.once(async () => {
+
+      try {
+        const url = this.extendUrlWithParams(this._manifestServiceUrl);
+        return await this._getManifest(url);
+      } catch (e) {
+        if (!e) {
+          e = new Error('Unknown error');
+        }
+        if (!(e instanceof Error)) {
+          e = new Error(e.data || `status ${e.statusText || e.status}`);
+        }
+        throw new Error(`Could not retrieve manifest from the tile service: ${e.message}`);
+      }
+    });
+
+
+    this._loadFileLayers = _.once(async () => {
+
+      const catalogue = await this._loadCatalogue();
+      const fileService = catalogue.services.find(service => service.type === 'file');
+      if (!fileService) {
+        return [];
+      }
+
+      const manifest = await this._getManifest(fileService.manifest, this._queryParams);
+
+      return manifest.layers.map(layerConfig => {
+        return new FileLayer(layerConfig, this);
+      });
+    });
+
+    this._loadTMSServices = _.once(async () => {
+
+      const catalogue = await this._loadCatalogue();
+      const tmsService = catalogue.services.find((service) => service.type === 'tms');
+      if (!tmsService) {
+        return [];
+      }
+      const tmsManifest = await this._getManifest(tmsService.manifest, this._queryParams);
+
+
+      return tmsManifest.services.map(serviceConfig => {
+        return new TMSService(serviceConfig, this);
+      });
+
+    });
+
+  }
+
+  //   getLandingPageUrl() {
+  //     return this._emsLandingPageUrl;
+  //   }
+
+  sanitizeMarkdown(markdown) {
+    return this._sanitizer(markdownIt.render(markdown));
+  }
+
+  sanitizeHtml(html) {
+    return this._sanitizer(html);
+  }
+
+  extendUrlWithParams(url) {
+    return unescapeTemplateVars(extendUrl(url, {
+      query: this._queryParams
+    }));
+  }
+
+  async getFileLayers() {
+    return await this._loadFileLayers();
+  }
+
+  async getTMSServices() {
+    return await this._loadTMSServices();
+  }
+
+  async findFileLayerById(id) {
+    const fileLayers = await this.getFileLayers();
+    for (let i = 0; i < fileLayers.length; i++) {
+      if (fileLayers[i].hasId(id)) {
+        return fileLayers[i];
+      }
+    }
+  }
+
+  async findTMSServiceById(id) {
+    const tmsServices = await this.getTMSServices();
+    for (let i = 0; i < tmsServices.length; i++) {
+      if (tmsServices[i].hasId(id)) {
+        return tmsServices[i];
+      }
+    }
+  }
+
+
+}

--- a/public/js/ems_client.js
+++ b/public/js/ems_client.js
@@ -53,16 +53,13 @@ export class EMSClientV66 {
 
   constructor({ manifestServiceUrl, htmlSanitizer, language }) {
 
-    this._queryParams = {
-    //   my_app_version: kbnVersion
-    };
+    this._queryParams = {};
 
     this._sanitizer = htmlSanitizer ? htmlSanitizer : x => x;
     this._manifestServiceUrl = manifestServiceUrl;
     this._loadCatalogue = null;
     this._loadFileLayers = null;
     this._loadTMSServices = null;
-    // this._emsLandingPageUrl = landingPageUrl;
     this._language = typeof language === 'string' ? language : DEFAULT_LANGUAGE;
 
     this._invalidateSettings();
@@ -156,10 +153,6 @@ export class EMSClientV66 {
     });
 
   }
-
-  //   getLandingPageUrl() {
-  //     return this._emsLandingPageUrl;
-  //   }
 
   sanitizeMarkdown(markdown) {
     return this._sanitizer(markdownIt.render(markdown));

--- a/public/js/file_layer.js
+++ b/public/js/file_layer.js
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import { ORIGIN } from './origin';
+
+export class FileLayer {
+
+  constructor(config, emsClient) {
+    this._config = config;
+    this._emsClient = emsClient;
+  }
+
+
+  getHTMLAttribution() {
+    const attributions = this._config.attribution.map(attribution => {
+      const url = this._emsClient.getValueInLanguage(attribution.url);
+      const label = this._emsClient.getValueInLanguage(attribution.label);
+      const html = url ? `<a href=${url}>${label}</a>` : label;
+      return this._emsClient.sanitizeHtml(html);
+    });
+    return attributions.join(', ');
+  }
+
+  getFieldsInLanguage() {
+    return this._config.fields.map(field => {
+      return {
+        type: field.type,
+        name: field.id,
+        description: this._emsClient.getValueInLanguage(field.label)
+      };
+    });
+  }
+
+  getDisplayName() {
+    const layerName = this._emsClient.getValueInLanguage(this._config.layer_name);
+    return (layerName)  ? layerName  : '';
+  }
+
+  getId() {
+    return this._config.layer_id;
+  }
+
+  hasId(id) {
+    const matchesLegacyId = this._config.legacy_ids.indexOf(id) >= 0;
+    return this._config.layer_id === id || matchesLegacyId;
+  }
+
+  _getDefaultFormat() {
+    const defaultFormat = this._config.formats.find(format => {
+      return format.legacy_default;
+    });
+    if (defaultFormat) {
+      return defaultFormat;
+    }
+    return this._config.formats[0];
+  }
+
+  getEMSHotLink() {
+    const id = `file/${this.getId()}`;
+    return `${this._emsClient.getLandingPageUrl()}#${id}`;
+  }
+
+  getDefaultFormatType() {
+    const format = this._getDefaultFormat();
+    return format.type;
+  }
+
+  getDefaultFormatMeta() {
+    const format = this._getDefaultFormat();
+    return format.meta;
+  }
+
+  getDefaultFormatUrl() {
+    const format = this._getDefaultFormat();
+    return this._emsClient.extendUrlWithParams(format.url);
+  }
+
+  getCreatedAt() {
+    return this._config.created_at;
+  }
+
+  getOrigin() {
+    return ORIGIN.EMS;
+  }
+
+}

--- a/public/js/modify_url.js
+++ b/public/js/modify_url.js
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { format as formatUrl, parse as parseUrl } from 'url';
+/**
+ *  Takes a URL and a function that takes the meaningful parts
+ *  of the URL as a key-value object, modifies some or all of
+ *  the parts, and returns the modified parts formatted again
+ *  as a url.
+ *
+ *  Url Parts sent:
+ *    - protocol
+ *    - slashes (does the url have the //)
+ *    - auth
+ *    - hostname (just the name of the host, no port or auth information)
+ *    - port
+ *    - pathname (the path after the hostname, no query or hash, starts
+ *        with a slash if there was a path)
+ *    - query (always an object, even when no query on original url)
+ *    - hash
+ *
+ *  Why?
+ *    - The default url library in node produces several conflicting
+ *      properties on the "parsed" output. Modifying any of these might
+ *      lead to the modifications being ignored (depending on which
+ *      property was modified)
+ *    - It's not always clear wither to use path/pathname, host/hostname,
+ *      so this tries to add helpful constraints
+ *
+ *  @param url the url to parse
+ *  @param block a function that will modify the parsed url, or return a new one
+ */
+export function modifyUrl(url, block) {
+  const parsed = parseUrl(url, true);
+  // copy over the most specific version of each
+  // property. By default, the parsed url includes
+  // several conflicting properties (like path and
+  // pathname + search, or search and query) and keeping
+  // track of which property is actually used when they
+  // are formatted is harder than necessary
+  const meaningfulParts = {
+    protocol: parsed.protocol,
+    slashes: parsed.slashes,
+    auth: parsed.auth,
+    hostname: parsed.hostname,
+    port: parsed.port,
+    pathname: parsed.pathname,
+    query: parsed.query || {},
+    hash: parsed.hash,
+  };
+    // the block modifies the meaningfulParts object, or returns a new one
+  const modifiedParts = block(meaningfulParts) || meaningfulParts;
+  // format the modified/replaced meaningfulParts back into a url
+  return formatUrl({
+    protocol: modifiedParts.protocol,
+    slashes: modifiedParts.slashes,
+    auth: modifiedParts.auth,
+    hostname: modifiedParts.hostname,
+    port: modifiedParts.port,
+    pathname: modifiedParts.pathname,
+    query: modifiedParts.query,
+    hash: modifiedParts.hash,
+  });
+}

--- a/public/js/origin.js
+++ b/public/js/origin.js
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const ORIGIN = {
+  EMS: 'elastic_maps_service',
+  KIBANA_YML: 'self_hosted'
+};

--- a/public/js/tms_service.js
+++ b/public/js/tms_service.js
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ORIGIN } from './origin';
+
+export class TMSService {
+
+  constructor(config,  emsClient) {
+    this._config = config;
+    this._emsClient = emsClient;
+  }
+
+  getUrlTemplate() {
+    return this._emsClient.extendUrlWithParams(this._config.url);
+  }
+
+  getHTMLAttribution() {
+    return this._emsClient.sanitizeMarkdown(this._config.attribution);
+  }
+
+  getMinZoom() {
+    return this._config.minZoom;
+  }
+
+  getMaxZoom() {
+    return this._config.maxZoom;
+  }
+
+  getId() {
+    return this._config.id;
+  }
+
+  hasId(id) {
+    return this._config.id === id;
+  }
+
+  getOrigin() {
+    return ORIGIN.EMS;
+  }
+
+}

--- a/public/main.js
+++ b/public/main.js
@@ -5,29 +5,32 @@ import ReactDOM from 'react-dom';
 import URL from 'url-parse';
 import CONFIG from './config.json';
 import { App } from './js/components/app';
-import { ManifestParserV2 } from './js/manifest_parser_v2';
+import { EMSClientV66 } from './js/ems_client';
 
 start();
 
 async function start() {
   const urlTokens = new URL(window.location, true);
-  const manifestParser = getManifestParser(urlTokens.query.manifest);
+  const emsClient = getEmsClient(urlTokens.query.manifest);
 
-  if (!manifestParser) {
+  if (!emsClient) {
     console.error(`Cannot load the required manifest for "${urlTokens.query.manifest}"`);
     return;
   }
-  const emsLayers = await manifestParser.getAllEMSLayers();
+  const emsLayers = {
+    file: await emsClient.getFileLayers(),
+    tms: await emsClient.getTMSServices()
+  };
 
   ReactDOM.render(<App layers={emsLayers}/>, document.getElementById('wrapper'));
 }
 
 
-function getManifestParser(deployment) {
+function getEmsClient(deployment) {
   if (!deployment) {
     deployment = CONFIG.default;
   }
   const url = CONFIG.SUPPORTED_EMS.manifest[deployment];
-  return (url) ? new ManifestParserV2(url) : null;
+  return (url) ? new EMSClientV66({ manifestServiceUrl: url }) : null;
 }
 


### PR DESCRIPTION
This updates the EMS Landing Page to work with the EMS v6.6 file manifest.

There are a few features in EMS v6.6 that this does not handle yet. 

 - [ ] Field semantics - Do we want to add the field type (`id` or `property`) to the table header?
 - [ ] Localization - This uses `en` by default. We might consider waiting to add localization for v6.7 to match Kibana.

After this is merged, Kibana should be updated to point to the v6.6 release of EMS Landing Page.