### PR TITLE
[v2] Use react-https-redirect to redirect to https

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "moment": "2.21.0",
     "react": "16.3.0",
     "react-dom": "16.3.0",
+    "react-https-redirect": "^1.0.11",
     "topojson-client": "3.0.0",
     "url-parse": "1.4.4",
     "whatwg-fetch": "^3.0.0"

--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import HttpsRedirect from 'react-https-redirect';
 
 import {
   EuiPage,
@@ -160,48 +161,50 @@ export class App extends Component {
     };
 
     return (
-      <div>
-        <EuiHeader>
-          <EuiHeaderSection>
-            <EuiHeaderSectionItem border="none">
-              <EuiHeaderLogo href="#" aria-label="Go to elastic.co" iconType="emsApp" >Elastic Maps Service</EuiHeaderLogo>
-            </EuiHeaderSectionItem>
-          </EuiHeaderSection>
-          <EuiHeaderSection side="right">
-            <EuiHeaderLinks>
-              <EuiHeaderLink href="//elastic.co">elastic.co</EuiHeaderLink>
-            </EuiHeaderLinks>
-          </EuiHeaderSection>
-        </EuiHeader>
-        <EuiPage>
-          <EuiPageBody>
-            <TableOfContents layers={this.props.layers} onFileLayerSelect={this._selectFileLayer} ref={setToc}/>
-            <div className="mainContent">
-              <EuiPanel paddingSize="none">
-                <Map ref={setMap}  baseLayer={this._baseLayer} />
-              </EuiPanel>
-              <EuiSpacer size="xl" />
-              <EuiPageContent>
-                <EuiPageContentBody>
-                  <LayerDetails layerConfig={this.state.selectedFileLayer} />
-                  <EuiSpacer size="l" />
-                  <FeatureTable
-                    ref={setFeatureTable}
-                    jsonFeatures={this.state.jsonFeatures}
-                    config={this.state.selectedFileLayer}
-                    onShow={this._showFeature}
-                    onFilterChange={this._filterFeatures}
-                  />
-                </EuiPageContentBody>
-              </EuiPageContent>
-              <EuiSpacer />
-              <EuiText size="xs" textAlign="center">
-                <p>Please submit any issues with this layer or suggestions for improving this layer in the <a href="https://github.com/elastic/kibana/issues/new" target="_blank">Kibana repo</a>.</p>
-              </EuiText>
-            </div>
-          </EuiPageBody>
-        </EuiPage>
-      </div>
+      <HttpsRedirect>
+        <div>
+          <EuiHeader>
+            <EuiHeaderSection>
+              <EuiHeaderSectionItem border="none">
+                <EuiHeaderLogo href="#" aria-label="Go to elastic.co" iconType="emsApp" >Elastic Maps Service</EuiHeaderLogo>
+              </EuiHeaderSectionItem>
+            </EuiHeaderSection>
+            <EuiHeaderSection side="right">
+              <EuiHeaderLinks>
+                <EuiHeaderLink href="//elastic.co">elastic.co</EuiHeaderLink>
+              </EuiHeaderLinks>
+            </EuiHeaderSection>
+          </EuiHeader>
+          <EuiPage>
+            <EuiPageBody>
+              <TableOfContents layers={this.props.layers} onFileLayerSelect={this._selectFileLayer} ref={setToc}/>
+              <div className="mainContent">
+                <EuiPanel paddingSize="none">
+                  <Map ref={setMap}  baseLayer={this._baseLayer} />
+                </EuiPanel>
+                <EuiSpacer size="xl" />
+                <EuiPageContent>
+                  <EuiPageContentBody>
+                    <LayerDetails layerConfig={this.state.selectedFileLayer} />
+                    <EuiSpacer size="l" />
+                    <FeatureTable
+                      ref={setFeatureTable}
+                      jsonFeatures={this.state.jsonFeatures}
+                      config={this.state.selectedFileLayer}
+                      onShow={this._showFeature}
+                      onFilterChange={this._filterFeatures}
+                    />
+                  </EuiPageContentBody>
+                </EuiPageContent>
+                <EuiSpacer />
+                <EuiText size="xs" textAlign="center">
+                  <p>Please submit any issues with this layer or suggestions for improving this layer in the <a href="https://github.com/elastic/kibana/issues/new" target="_blank">Kibana repo</a>.</p>
+                </EuiText>
+              </div>
+            </EuiPageBody>
+          </EuiPage>
+        </div>
+      </HttpsRedirect>
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6065,6 +6065,13 @@ react-dom@16.3.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-https-redirect@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/react-https-redirect/-/react-https-redirect-1.0.11.tgz#c1a66594de58ba29afec616574ed946ab779694d"
+  integrity sha512-4ZmiF5mKk0QgNCMw0VquGlBwaOdWMrZRIJg9dEGj1Xu/0fzhx3imd5hOmPWje8FsL3AghlvdEcNS7xXA/ueiOQ==
+  dependencies:
+    prop-types "^15.5.8"
+
 react-input-autosize@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"


### PR DESCRIPTION
This uses the[ react-https-redirect ](https://github.com/mbasso/react-https-redirect) library to redirect http to https. This also has the benefit of not redirecting when using `http://localhost:<port>` in development. To test https redirection in development, use `http://0.0.0.0:<port>`.

Fixes #18 