### PR TITLE
Update 7.0 version to use EMS 7.0 manifests

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,10 +1,10 @@
 {
   "default": "production",
   "SUPPORTED_EMS": {
-    "version": "v6.6",
+    "version": "v7.0",
     "manifest": {
-      "staging": "https://catalogue-staging.maps.elastic.co/v6.6/manifest",
-      "production": "https://catalogue.maps.elastic.co/v6.6/manifest"
+      "staging": "https://catalogue-staging.maps.elastic.co/v7.0/manifest",
+      "production": "https://catalogue.maps.elastic.co/v7.0/manifest"
     }
   },
   "SUPPORTED_LOCALE": {


### PR DESCRIPTION
New layers will be changing for 7.0 release so we should use the correct manifests.