### PR TITLE
[v6.7] Safe locale check

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -38,7 +38,7 @@ function getEmsClient(deployment, locale) {
     deployment = CONFIG.default;
   }
   const url = CONFIG.SUPPORTED_EMS.manifest[deployment];
-  const language = locale && CONFIG.SUPPORTED_LOCALE[locale.toLowerCase()]
+  const language = locale && CONFIG.SUPPORTED_LOCALE.hasOwnProperty(locale.toLowerCase())
     ? locale : null;
   return (url) ? new EMSClientV66({ manifestServiceUrl: url, language: language }) : null;
 }


### PR DESCRIPTION
This implements a safer check for locale inputs as well as merging the deployment input check from v6.6.

This should get merged into v7.0.

Replaces #84.