### PR TITLE
[v6.6] Enable higher zoom levels

### DIFF
--- a/deployProduction.sh
+++ b/deployProduction.sh
@@ -45,6 +45,7 @@ if [[ "$1" != "nodocker" ]]; then
         --env GPROJECT \
         --env HOME=/tmp \
         --volume $PWD:/app \
+        --user=$(id -u):$(id -g) \
         --workdir /app \
         'google/cloud-sdk:slim' \
         /app/deployProduction.sh nodocker "$@"

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "mapbox-gl": "0.52.0",
     "markdown-it": "8.4.2",
     "moment": "2.21.0",
+    "querystring-browser": "^1.0.4",
     "react": "16.3.0",
     "react-dom": "16.3.0",
     "react-https-redirect": "^1.0.11",

--- a/public/config.json
+++ b/public/config.json
@@ -6,5 +6,6 @@
       "staging": "https://catalogue-staging.maps.elastic.co/v6.6/manifest",
       "production": "https://catalogue.maps.elastic.co/v6.6/manifest"
     }
-  }
+  },
+  "license": "643c1faf-80fc-4ab0-9323-4d9bd11f4bbc"
 }

--- a/public/js/manifest_parser_v2.js
+++ b/public/js/manifest_parser_v2.js
@@ -4,9 +4,26 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { parse } from 'url';
+import { stringify } from 'querystring';
+
 export class ManifestParserV2 {
-  constructor(url) {
-    this._url = url;
+  constructor(url, license) {
+    this._license = license;
+    this._url = this._extendUrlWithLicense(url);
+  }
+
+  _extendUrlWithLicense(url) {
+    if (!this._license) return url;
+    const urlObject = parse(url, true);
+    const queryParams = Object.assign(
+      urlObject.query,
+      { license: this._license }
+    );
+    // We can't use url.format() here because it escapes the template characters (e.g. <x>)
+    return urlObject.search
+      ? url.replace(urlObject.search, `?${stringify(queryParams)}`)
+      : url;
   }
 
   async getCatalogue() {
@@ -23,12 +40,19 @@ export class ManifestParserV2 {
     const catalogue = await this.getCatalogue();
 
     const tilesMeta = catalogue.services.find(service => service.type === 'tms');
-    const tilesResponse = await fetch(tilesMeta.manifest);
+    const tilesResponse = await fetch(this._extendUrlWithLicense(tilesMeta.manifest));
     const tilesManifest = await tilesResponse.json();
-
+    // Mutate the service url to include license parameter if available
+    for (const service of tilesManifest.services) {
+      service.url = this._extendUrlWithLicense(service.url);
+    }
     const filesMeta = catalogue.services.find(service => service.type === 'file');
-    const filesResponse = await fetch(filesMeta.manifest);
+    const filesResponse = await fetch(this._extendUrlWithLicense(filesMeta.manifest));
     const filesManifest = await filesResponse.json();
+    // Mutate the vector url to include license parameter if available
+    for (const layer of filesManifest.layers) {
+      layer.url = this._extendUrlWithLicense(layer.url);
+    }
 
     return {
       tms: {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -47,6 +47,7 @@ module.exports = {
   },
   resolve: {
     alias: {
+      querystring: 'querystring-browser'
     }
   },
   optimization: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7982,6 +7982,11 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+querystring-browser@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/querystring-browser/-/querystring-browser-1.0.4.tgz#f2e35881840a819bc7b1bf597faf0979e6622dc6"
+  integrity sha1-8uNYgYQKgZvHsb9Zf68JeeZiLcY=
+
 querystring-es3@^0.2.0, querystring-es3@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -8517,6 +8522,7 @@ require-uncached@^1.0.3:
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 resize-img@^1.1.0:
   version "1.1.2"


### PR DESCRIPTION
Forward porting #93 into v6.6.

Fixes #91. This PR adds support for higher zoom levels on https://maps.elastic.co via a configurable Elastic Maps Service license key.