### PR TITLE
Add testing manifest for new layers

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,7 +1,6 @@
 {
   "default": "production",
   "SUPPORTED_EMS": {
-    "version": "v7.0",
     "manifest": {
       "testing": "http://storage.googleapis.com/elastic-bekitzur-emsfiles-catalogue-dev/v7.2/manifest",
       "staging": "https://catalogue-staging.maps.elastic.co/v7.2/manifest",

--- a/public/config.json
+++ b/public/config.json
@@ -3,6 +3,7 @@
   "SUPPORTED_EMS": {
     "version": "v7.0",
     "manifest": {
+      "testing": "http://storage.googleapis.com/elastic-bekitzur-emsfiles-catalogue-dev/v7.2/manifest",
       "staging": "https://catalogue-staging.maps.elastic.co/v7.2/manifest",
       "production": "https://catalogue.maps.elastic.co/v7.2/manifest"
     }


### PR DESCRIPTION
New layers in the `feature-layers` branch of the ems-file-service can
be tested by adding `?manifest=testing` to the URL.