### PR TITLE
[v7.2] Add testing manifest for new layers (#117)

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,8 +1,8 @@
 {
   "default": "production",
   "SUPPORTED_EMS": {
-    "version": "v7.0",
     "manifest": {
+      "testing": "http://storage.googleapis.com/elastic-bekitzur-emsfiles-catalogue-dev/v7.2/manifest",
       "staging": "https://catalogue-staging.maps.elastic.co/v7.2/manifest",
       "production": "https://catalogue.maps.elastic.co/v7.2/manifest"
     }


### PR DESCRIPTION
Backports the following commits to v7.2:
 - Add testing manifest for new layers (#117)