### PR TITLE
[v7.2] testing url should be https (#119)

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -2,7 +2,7 @@
   "default": "production",
   "SUPPORTED_EMS": {
     "manifest": {
-      "testing": "http://storage.googleapis.com/elastic-bekitzur-emsfiles-catalogue-dev/v7.2/manifest",
+      "testing": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-catalogue-dev/v7.2/manifest",
       "staging": "https://catalogue-staging.maps.elastic.co/v7.2/manifest",
       "production": "https://catalogue.maps.elastic.co/v7.2/manifest"
     }


### PR DESCRIPTION
Backports the following commits to v7.2:
 - testing url should be https (#119)