### PR TITLE
Enable higher zoom levels

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -7,6 +7,7 @@
       "production": "https://catalogue.maps.elastic.co/v7.2/manifest"
     }
   },
+  "license": "643c1faf-80fc-4ab0-9323-4d9bd11f4bbc",
   "SUPPORTED_LOCALE": {
       "aa": "Qafár af",
       "ab": "Аҧсшәа",

--- a/public/main.js
+++ b/public/main.js
@@ -38,6 +38,12 @@ function getEmsClient(deployment, locale) {
     : CONFIG.SUPPORTED_EMS.manifest[CONFIG.default];
   const language = locale && CONFIG.SUPPORTED_LOCALE.hasOwnProperty(locale.toLowerCase())
     ? locale : null;
-  return (url) ? new EMSClient({ kbnVersion: '7.4.0', manifestServiceUrl: url, language: language }) : null;
+
+  const license = CONFIG.hasOwnProperty('license') ? CONFIG['license'] : null;
+  const emsClient = new EMSClient({ kbnVersion: '7.4.0', manifestServiceUrl: url, language: language });
+  if (license) {
+    emsClient.addQueryParams({ license });
+  }
+  return emsClient;
 }
 

--- a/public/main.js
+++ b/public/main.js
@@ -39,7 +39,7 @@ function getEmsClient(deployment, locale) {
   const language = locale && CONFIG.SUPPORTED_LOCALE.hasOwnProperty(locale.toLowerCase())
     ? locale : null;
 
-  const license = CONFIG.hasOwnProperty('license') ? CONFIG['license'] : null;
+  const license = CONFIG.license;
   const emsClient = new EMSClient({ kbnVersion: '7.4.0', manifestServiceUrl: url, language: language });
   if (license) {
     emsClient.addQueryParams({ license });


### PR DESCRIPTION
Fixes #91. This adds a configurable license to enable zoom levels greater than 10 for basemaps.

This should be backported to 7.4.