### PR TITLE
Bind the client fetch function to the ems-client library

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -32,12 +32,16 @@ async function start() {
   ReactDOM.render(<App client={emsClient} layers={emsLayers} />, document.getElementById('wrapper'));
 }
 
+function fetchFunction (...args) {
+  return fetch(...args);
+}
+
 function getEmsClient(deployment, locale) {
   const url = CONFIG.SUPPORTED_EMS.manifest.hasOwnProperty(deployment)
     ? CONFIG.SUPPORTED_EMS.manifest[deployment]
     : CONFIG.SUPPORTED_EMS.manifest[CONFIG.default];
   const language = locale && CONFIG.SUPPORTED_LOCALE.hasOwnProperty(locale.toLowerCase())
     ? locale : null;
-  return (url) ? new EMSClient({ kbnVersion: '7.4.0', manifestServiceUrl: url, language: language }) : null;
+  return (url) ? new EMSClient({ kbnVersion: '7.4.0', manifestServiceUrl: url, language: language, fetchFunction }) : null;
 }
 


### PR DESCRIPTION
Fixes #126. The @elastic/ems-client library uses node-fetch by default unless the `fetchFunction` parameter is specified in the constructor. In Firefox and Safari, the node-fetch library overrides the built-in browser `fetch` function. We can pass the browser's `fetch` function to the library instead.

This is the [same implementation that is used in Kibana](https://github.com/elastic/kibana/blob/d0e48497f47a170c13a25efee6b10495582c8587/x-pack/legacy/plugins/maps/public/meta.js#L35-L37).

Reviewers, if possible please test this in Firefox and Safari. The bug does not appear in Chrome.