### PR TITLE
Update https://maps.elastic.co to the v7.4 branch

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -19,7 +19,7 @@
           &lt;commitId&gt;, etc.)
     - string:
         name: root_branch
-        default: 'v7.2'
+        default: 'v7.4'
         description: Which branch should also be available as the maps.elastic.co root
     node: linux && !oraclelinux
     scm:


### PR DESCRIPTION
Now that 7.4 is released, let's update https://maps.elastic.co to the v7.4 branch which has vector tiles.