### PR TITLE
[v7.4] Bump @elastic/ems-client to latest patch (#151)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.2",
-    "@elastic/ems-client": "^1.0.5",
+    "@elastic/ems-client": "^7.2.2",
     "@elastic/eui": "^14.8.0",
     "@turf/bbox": "6.0.1",
     "@turf/center": "6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,10 +789,10 @@
   dependencies:
     tslib "^1.9.3"
 
-"@elastic/ems-client@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-1.0.5.tgz#e2c10816c5eebdf128590170d8f09fcc693db50b"
-  integrity sha512-J+jDjtpHfGnbsgdhuA1zp/JoZftCpx6/h/4bP5ik+2Ysa30sAHIpHs0D3921R75O9WDNs6SHVnV/oqdJKL/HCg==
+"@elastic/ems-client@^7.2.2":
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.2.2.tgz#217b4b0ce0959e8588038311781b821c6cad5074"
+  integrity sha512-OAJocu7FVeQ/eaXnoODrd5pPpPhwmSpQEbhvGL2ruxNjGSvZmlFTXBuVUCL+9jidCjidw8W3uK5FaDSiStR8lg==
   dependencies:
     lodash "^4.17.15"
     node-fetch "^1.7.3"


### PR DESCRIPTION
Backports the following commits to v7.4:
 - Bump @elastic/ems-client to latest patch (#151)