### PR TITLE
Add support for RTL languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@elastic/datemath": "^5.0.2",
     "@elastic/ems-client": "^7.2.2",
     "@elastic/eui": "^14.8.0",
+    "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.0.1",
     "@turf/center": "6.0.1",
     "mapbox-gl": "1.5.0",

--- a/public/js/components/map.js
+++ b/public/js/components/map.js
@@ -5,9 +5,13 @@
  */
 
 import mapboxgl from 'mapbox-gl';
+// eslint-disable-next-line import/no-unresolved
+import mbRtlPlugin from '!!file-loader!@mapbox/mapbox-gl-rtl-text/mapbox-gl-rtl-text.min.js';
 import turfBbox from '@turf/bbox';
 import turfCenter from '@turf/center';
 import React, { Component } from 'react';
+
+mapboxgl.setRTLTextPlugin(mbRtlPlugin);
 
 export class Map extends Component {
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,6 +800,7 @@
 "@elastic/eslint-config-kibana@^0.15.0":
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/@elastic/eslint-config-kibana/-/eslint-config-kibana-0.15.0.tgz#a552793497cdfc1829c2f9b7cd7018eb008f1606"
+  integrity sha1-pVJ5NJfN/Bgpwvm3zXAY6wCPFgY=
 
 "@elastic/eui@^14.8.0":
   version "14.8.0"
@@ -1104,6 +1105,11 @@
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
   integrity sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=
+
+"@mapbox/mapbox-gl-rtl-text@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-rtl-text/-/mapbox-gl-rtl-text-0.2.3.tgz#a26ecfb3f0061456d93ee8570dd9587d226ea8bd"
+  integrity sha512-RaCYfnxULUUUxNwcUimV9C/o2295ktTyLEUzD/+VWkqXqvaVfFcZ5slytGzb2Sd/Jj4MlbxD0DCZbfa6CzcmMw==
 
 "@mapbox/mapbox-gl-supported@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
Support for RTL languages (such as Arabic and Hebrew) [was added to Kibana in v7.6.0](https://github.com/elastic/kibana/pull/54842). We should also add support in the v7.6 release here. 

For example, note the respective Arabic and Hebrew labels for [Cairo](https://en.wikipedia.org/wiki/Cairo) and [Tel Aviv](https://en.wikipedia.org/wiki/Tel_Aviv) in the screenshots below.

Before:
![Screenshot_2020-01-15 Elastic Maps Service(1)](https://user-images.githubusercontent.com/1638483/72454897-a1e48c80-3776-11ea-9ffe-4c8f0c3914ec.png)


After:
![Screenshot_2020-01-15 Elastic Maps Service](https://user-images.githubusercontent.com/1638483/72454916-a90b9a80-3776-11ea-8ec1-658675d316bd.png)
