### PR TITLE
Fix webpack warning about iconv-loader

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -22,6 +22,7 @@ module.exports = {
     filename: '[name].bundle.js'
   },
   module: {
+    noParse: /iconv-loader\.js/,
     rules: [
       {
         test: /\.(png|jpg|gif|svg)$/,


### PR DESCRIPTION
ems-client has a dependency on node-fetch which is only used for Node.js. Webpack throws a warning when it sees the iconv-loader.js file in the encoding dependency of node-fetch. We only use the browser target of ems-client so node-fetch is not used here. So we can avoid this warning by telling webpack to ignore the iconv-loader.js file.