### PR TITLE
Add v7.6 branch to ci

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,7 @@
 {
   "upstream": "elastic/ems-landing-page",
   "branches": [
+    { "name": "v7.6", "checked":  true },
     { "name": "v7.4", "checked":  true },
     { "name": "v7.2", "checked":  true },
     { "name": "v7.0", "checked":  true },

--- a/.ci/jobs/elastic+ems-landing-page+v7.6.yml
+++ b/.ci/jobs/elastic+ems-landing-page+v7.6.yml
@@ -1,0 +1,30 @@
+---
+- job:
+    name: elastic+ems-landing-page+v7.6+stage
+    display-name: 'elastic / ems-landing-page # v7.6 - stage'
+    description: Build and deploy v7.6 branch to staging server using ./deployStaging.sh.
+    parameters:
+    - string:
+        name: branch_specifier
+        default: refs/heads/v7.6
+        description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
+          &lt;commitId&gt;, etc.)
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -e
+        set +x
+
+        export ROOT_BRANCH=$root_branch
+        export GPROJECT=elastic-bekitzur
+        VAULT_ACCOUNT=secret/gce/$GPROJECT/service-account/jenkins
+
+        VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        GCE_ACCOUNT=$(vault read -field=value $VAULT_ACCOUNT)
+        export GCE_ACCOUNT
+        unset VAULT_ROLE_ID VAULT_SECRET_ID VAULT_ADDR VAULT_TOKEN VAULT_ACCOUNT
+
+        # Expects env: GPROJECT, GCE_ACCOUNT, GIT_BRANCH, ROOT_BRANCH
+        # Run EMS script, set in the template parameter
+        ./deployStaging.sh


### PR DESCRIPTION
This will add v7.6 branch to CI to build the v7.6 version of ems-landing-page. After publishing the v7.6 version will be available at https://maps.elastic.co/v7.6. 

This follows the instructions for adding a new version in the [CONTRIBUTING.md](https://github.com/elastic/ems-landing-page/blob/master/CONTRIBUTING.md#new-releases).