### PR TITLE
[v7.4] Fix webpack warning about iconv-loader (#155)

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -22,6 +22,7 @@ module.exports = {
     filename: '[name].bundle.js'
   },
   module: {
+    noParse: /iconv-loader\.js/,
     rules: [
       {
         test: /\.(png|jpg|gif|svg)$/,


### PR DESCRIPTION
Backports the following commits to v7.4:
 - Fix webpack warning about iconv-loader (#155)