### PR TITLE
Default to v7.6

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,7 @@
 {
   "upstream": "elastic/ems-landing-page",
   "branches": [
+    { "name": "v7.6", "checked": true },
     { "name": "v7.4", "checked":  true },
     { "name": "v7.2", "checked":  true },
     { "name": "v7.0", "checked":  true },

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -19,7 +19,7 @@
           &lt;commitId&gt;, etc.)
     - string:
         name: root_branch
-        default: 'v7.4'
+        default: 'v7.6'
         description: Which branch should also be available as the maps.elastic.co root
     node: linux && !oraclelinux
     scm:


### PR DESCRIPTION
This PR will update https://maps.elastic.co to use the v7.6 branch.