### PR TITLE
Update to EMS v7.7

### DIFF
--- a/.ci/jobs/elastic+ems-landing-page+v7.7.yml
+++ b/.ci/jobs/elastic+ems-landing-page+v7.7.yml
@@ -1,0 +1,30 @@
+---
+- job:
+    name: elastic+ems-landing-page+v7.7+stage
+    display-name: 'elastic / ems-landing-page # v7.7 - stage'
+    description: Build and deploy v7.7 branch to staging server using ./deployStaging.sh.
+    parameters:
+    - string:
+        name: branch_specifier
+        default: refs/heads/v7.7
+        description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
+          &lt;commitId&gt;, etc.)
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -e
+        set +x
+
+        export ROOT_BRANCH=$root_branch
+        export GPROJECT=elastic-bekitzur
+        VAULT_ACCOUNT=secret/gce/$GPROJECT/service-account/jenkins
+
+        VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        GCE_ACCOUNT=$(vault read -field=value $VAULT_ACCOUNT)
+        export GCE_ACCOUNT
+        unset VAULT_ROLE_ID VAULT_SECRET_ID VAULT_ADDR VAULT_TOKEN VAULT_ACCOUNT
+
+        # Expects env: GPROJECT, GCE_ACCOUNT, GIT_BRANCH, ROOT_BRANCH
+        # Run EMS script, set in the template parameter
+        ./deployStaging.sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ems_landing_page",
-  "version": "7.6.0",
+  "version": "7.7.0",
   "description": "",
   "main": "main.js",
   "devDependencies": {
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.2",
-    "@elastic/ems-client": "7.6.0",
+    "@elastic/ems-client": "7.7.0",
     "@elastic/eui": "^14.8.0",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.2",
-    "@elastic/ems-client": "7.7.0",
+    "@elastic/ems-client": "7.7.1",
     "@elastic/eui": "^14.8.0",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.0.1",

--- a/public/config.json
+++ b/public/config.json
@@ -1,7 +1,7 @@
 {
   "default": "production",
   "SUPPORTED_EMS": {
-    "emsVersion": "v7.6",
+    "emsVersion": "v7.7",
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",

--- a/public/main.js
+++ b/public/main.js
@@ -54,7 +54,15 @@ async function getEmsClient(deployment, locale) {
     ? locale : null;
 
   const license = config.license;
-  const emsClient = new EMSClient({ kbnVersion: version, fileApiUrl, tileApiUrl, emsVersion, language: language, fetchFunction });
+  const emsClient = new EMSClient({
+    appName: 'ems-landing-page',
+    appVersion: version,
+    fileApiUrl,
+    tileApiUrl,
+    emsVersion,
+    language: language,
+    fetchFunction,
+  });
   if (license) {
     emsClient.addQueryParams({ license });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,10 +789,10 @@
   dependencies:
     tslib "^1.9.3"
 
-"@elastic/ems-client@7.7.0":
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.7.0.tgz#7d36d716dd941f060b9fcdae94f186a9aecc5cc2"
-  integrity sha512-JatsSyLik/8MTEOEimzEZ3NYjvGL1YzjbGujuSCgaXhPRqzu/wvMLEL8dlVpmYFZ7ALbGNsVdho4Hr8tngsIMw==
+"@elastic/ems-client@7.7.1":
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.7.1.tgz#cda9277cb851b6d1aa0408fe2814de98f1474fb8"
+  integrity sha512-8ikEUbsM+wxENqi/cwrmo4+2vwZkVoFDPSIrw3bQG2mQaE3l+3w1eMPKxsvQq0r79ivzXJ51gkvr8CffBkBkGw==
   dependencies:
     lodash "^4.17.15"
     node-fetch "^1.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,10 +789,10 @@
   dependencies:
     tslib "^1.9.3"
 
-"@elastic/ems-client@7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.6.0.tgz#ca548aba1a1f5170a1892de129b537b5248c74be"
-  integrity sha512-oBtLH24qIgTaMhlSske49FTd35Y0nv+PlZCZaHkBhOH+ScsTDL3LO2lbIcSmcYQod43Ly34v/xwJvFCTxojVEQ==
+"@elastic/ems-client@7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.7.0.tgz#7d36d716dd941f060b9fcdae94f186a9aecc5cc2"
+  integrity sha512-JatsSyLik/8MTEOEimzEZ3NYjvGL1YzjbGujuSCgaXhPRqzu/wvMLEL8dlVpmYFZ7ALbGNsVdho4Hr8tngsIMw==
   dependencies:
     lodash "^4.17.15"
     node-fetch "^1.7.3"


### PR DESCRIPTION
Things to check for:
* Requests for tile and file manifests should be `.../v7.7/manifest`
* `my_app_name=ems-landing-page` in query string requests
* `my_app_version=7.7.0` in query string requests 

First we should merge https://github.com/elastic/ems-client/pull/19, publish @elastic/ems-client@7.7.1, and update the dependency in this PR.