### PR TITLE
[v7.7] Allow relative API URLs in config (#181)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.2",
-    "@elastic/ems-client": "7.7.1",
+    "@elastic/ems-client": "7.7.2",
     "@elastic/eui": "^14.8.0",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.0.1",

--- a/public/js/components/map.js
+++ b/public/js/components/map.js
@@ -36,7 +36,10 @@ export class Map extends Component {
       style: {
         version: 8,
         sources: {},
-        layers: []
+        layers: [],
+      },
+      transformRequest: (url) => {
+        return { url: new URL(url, window.location.origin).href };
       },
     });
     this._mapboxMap.dragRotate.disable();

--- a/public/main.js
+++ b/public/main.js
@@ -26,14 +26,24 @@ async function start() {
   }
   const emsLayers = {
     file: await emsClient.getFileLayers(),
-    tms: await emsClient.getTMSServices()
+    tms: await emsClient.getTMSServices(),
   };
 
-  ReactDOM.render(<App client={emsClient} layers={emsLayers} />, document.getElementById('wrapper'));
+  ReactDOM.render(
+    <App client={emsClient} layers={emsLayers} />,
+    document.getElementById('wrapper')
+  );
 }
 
-function fetchFunction (...args) {
+function fetchFunction(...args) {
   return fetch(...args);
+}
+
+function relativeToAbsolute(url) {
+  // convert all link urls to absolute urls
+  const a = document.createElement('a');
+  a.setAttribute('href', url);
+  return a.href;
 }
 
 async function getEmsClient(deployment, locale) {
@@ -48,10 +58,14 @@ async function getEmsClient(deployment, locale) {
     ? config.SUPPORTED_EMS.manifest[deployment]
     : config.SUPPORTED_EMS.manifest[config.default];
   const emsVersion = manifest.hasOwnProperty('emsVersion') ? manifest['emsVersion'] : null;
-  const fileApiUrl = manifest.hasOwnProperty('emsFileApiUrl') ? manifest['emsFileApiUrl'] : null;
-  const tileApiUrl = manifest.hasOwnProperty('emsTileApiUrl') ? manifest['emsTileApiUrl'] : null;
-  const language = locale && config.SUPPORTED_LOCALE.hasOwnProperty(locale.toLowerCase())
-    ? locale : null;
+  const fileApiUrl = manifest.hasOwnProperty('emsFileApiUrl')
+    ? relativeToAbsolute(manifest['emsFileApiUrl'])
+    : null;
+  const tileApiUrl = manifest.hasOwnProperty('emsTileApiUrl')
+    ? relativeToAbsolute(manifest['emsTileApiUrl'])
+    : null;
+  const language =
+    locale && config.SUPPORTED_LOCALE.hasOwnProperty(locale.toLowerCase()) ? locale : null;
 
   const license = config.license;
   const emsClient = new EMSClient({
@@ -68,4 +82,3 @@ async function getEmsClient(deployment, locale) {
   }
   return emsClient;
 }
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,10 +887,10 @@
   dependencies:
     tslib "^1.9.3"
 
-"@elastic/ems-client@7.7.1":
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.7.1.tgz#cda9277cb851b6d1aa0408fe2814de98f1474fb8"
-  integrity sha512-8ikEUbsM+wxENqi/cwrmo4+2vwZkVoFDPSIrw3bQG2mQaE3l+3w1eMPKxsvQq0r79ivzXJ51gkvr8CffBkBkGw==
+"@elastic/ems-client@7.7.2":
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.7.2.tgz#c94a567b2d09f29132f3b92cff48144c29df4a79"
+  integrity sha512-X/JDE8ZcGouvxtw5c+z4huTY+pirxZ0pjTbD34vhAQAuuXrih8UDn+8hdijBt8u2HdfFsJxH968W0Wtx4oNzcA==
   dependencies:
     lodash "^4.17.15"
     node-fetch "^1.7.3"


### PR DESCRIPTION
Backports the following commits to v7.7:
 - Allow relative API URLs in config (#181)