### PR TITLE
Handle empty #file anchor in URL

### DIFF
--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -136,6 +136,8 @@ export class App extends Component {
     }
 
     const id = decodeURIComponent(tokens[1]);
+    if (!id || id === 'undefined') return null;
+
     return {
       path: `file/${id}`,
       config: this.props.layers.file.find(layer => layer.hasId(id))

--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -136,7 +136,9 @@ export class App extends Component {
     }
 
     const id = decodeURIComponent(tokens[1]);
-    if (!id || id === 'undefined') return null;
+    if (!id || id === 'undefined') {
+      return;
+    }
 
     return {
       path: `file/${id}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,9 +1508,9 @@ acorn-jsx@^5.1.0:
   integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
 
 acorn@^6.2.1:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
-  integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
+  integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
 acorn@^7.1.0:
   version "7.1.0"


### PR DESCRIPTION
Fixes #88 

When the #file anchor in the URL is empty it should redirect to the first layer ("world_countries"). 

Here are some URLs to test.
 - http://localhost:8080/#file compare against https://maps.elastic.co/#file
 - http://localhost:8080/#file/ compare against https://maps.elastic.co/#file/
 - http://localhost:8080/# compare against https://maps.elastic.co/# (should work in both)