### PR TITLE
[v7.6] Handle empty #file anchor in URL (#186)

### DIFF
--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -136,6 +136,10 @@ export class App extends Component {
     }
 
     const id = decodeURIComponent(tokens[1]);
+    if (!id || id === 'undefined') {
+      return;
+    }
+
     return {
       path: `file/${id}`,
       config: this.props.layers.file.find(layer => layer.hasId(id))


### PR DESCRIPTION
Backports the following commits to v7.6:
 - Handle empty #file anchor in URL (#186)