### PR TITLE
[v7.0] Handle empty #file anchor in URL (#186)

### DIFF
--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -127,6 +127,10 @@ export class App extends Component {
     }
 
     const id = decodeURIComponent(tokens[1]);
+    if (!id || id === 'undefined') {
+      return;
+    }
+
     return {
       path: `file/${id}`,
       config: this.props.layers.file.find(layer => layer.hasId(id))


### PR DESCRIPTION
Backports the following commits to v7.0:
 - Handle empty #file anchor in URL (#186)