### PR TITLE
Bump package.json version for 7.8

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ To add a new release:
 1. Create a new config in the [.ci/jobs](https://github.com/elastic/ems-landing-page/tree/master/.ci/jobs) directory for a new release branch on the `master` branch.
 1. Change the EMS_VERSION in config.json.
 1. Upgrade the ems-client dependency.
+1. Bump the verison in package.json.
 1. Create the new release branch from the `master` branch.
 
 After release:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ems_landing_page",
-  "version": "7.7.0",
+  "version": "7.8.0",
   "description": "",
   "main": "main.js",
   "devDependencies": {


### PR DESCRIPTION
😅  

In order to send the correct `my_app_version` query parameter to the API, we need to bump the package.json version. 