### PR TITLE
[v7.8] Publish 7.8 (#198) | Bump package.json version for 7.8 (#199)

### DIFF
--- a/.ci/jobs/elastic+ems-landing-page+v7.8.yml
+++ b/.ci/jobs/elastic+ems-landing-page+v7.8.yml
@@ -1,0 +1,30 @@
+---
+- job:
+    name: elastic+ems-landing-page+v7.8+stage
+    display-name: 'elastic / ems-landing-page # v7.8 - stage'
+    description: Build and deploy v7.8 branch to staging server using ./deployStaging.sh.
+    parameters:
+    - string:
+        name: branch_specifier
+        default: refs/heads/v7.8
+        description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
+          &lt;commitId&gt;, etc.)
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -e
+        set +x
+
+        export ROOT_BRANCH=$root_branch
+        export GPROJECT=elastic-bekitzur
+        VAULT_ACCOUNT=secret/gce/$GPROJECT/service-account/maps-landing
+
+        VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        GCE_ACCOUNT=$(vault read -field=value $VAULT_ACCOUNT)
+        export GCE_ACCOUNT
+        unset VAULT_ROLE_ID VAULT_SECRET_ID VAULT_ADDR VAULT_TOKEN VAULT_ACCOUNT
+
+        # Expects env: GPROJECT, GCE_ACCOUNT, GIT_BRANCH, ROOT_BRANCH
+        # Run EMS script, set in the template parameter
+        ./deployStaging.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ New releases of EMS Landing Page match minor releases of the Elastic Stack.
 
 To add a new release:
 1. Create a new config in the [.ci/jobs](https://github.com/elastic/ems-landing-page/tree/master/.ci/jobs) directory for a new release branch on the `master` branch.
+1. Change the EMS_VERSION in config.json.
+1. Upgrade the ems-client dependency.
 1. Create the new release branch from the `master` branch.
 
 After release:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ To add a new release:
 1. Create a new config in the [.ci/jobs](https://github.com/elastic/ems-landing-page/tree/master/.ci/jobs) directory for a new release branch on the `master` branch.
 1. Change the EMS_VERSION in config.json.
 1. Upgrade the ems-client dependency.
+1. Bump the verison in package.json.
 1. Create the new release branch from the `master` branch.
 
 After release:

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.2",
-    "@elastic/ems-client": "7.7.2",
+    "@elastic/ems-client": "7.8.1",
     "@elastic/eui": "^14.8.0",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ems_landing_page",
-  "version": "7.7.0",
+  "version": "7.8.0",
   "description": "",
   "main": "main.js",
   "devDependencies": {

--- a/public/config.json
+++ b/public/config.json
@@ -1,7 +1,7 @@
 {
   "default": "production",
   "SUPPORTED_EMS": {
-    "emsVersion": "v7.7",
+    "emsVersion": "v7.8",
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,13 +887,12 @@
   dependencies:
     tslib "^1.9.3"
 
-"@elastic/ems-client@7.7.2":
-  version "7.7.2"
-  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.7.2.tgz#c94a567b2d09f29132f3b92cff48144c29df4a79"
-  integrity sha512-X/JDE8ZcGouvxtw5c+z4huTY+pirxZ0pjTbD34vhAQAuuXrih8UDn+8hdijBt8u2HdfFsJxH968W0Wtx4oNzcA==
+"@elastic/ems-client@7.8.1":
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.8.1.tgz#6ce188d90f6b86d49fdadbecd2549c65b7a2f415"
+  integrity sha512-Y3Aw3QhjxcCmmhDMkq8faeLXIN6FQVGZaolOG57WjLMgXFHFAL791bdRTN+YTPUqyXwBwsFMdVKrov0C6k4lNA==
   dependencies:
     lodash "^4.17.15"
-    node-fetch "^1.7.3"
     semver "^6.3.0"
 
 "@elastic/eslint-config-kibana@^0.15.0":
@@ -3675,13 +3674,6 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
-
 end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -5105,7 +5097,7 @@ husky@^3.0.9:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5560,7 +5552,7 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -6565,14 +6557,6 @@ node-dir@^0.1.10:
   integrity sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=
   dependencies:
     minimatch "^3.0.2"
-
-node-fetch@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@0.9.0:
   version "0.9.0"


### PR DESCRIPTION
Backports the following commits to v7.8:
 - Publish 7.8 (#198)
 - Bump package.json version for 7.8 (#199)