### PR TITLE
[v7.7] Bump https://maps.elastic.co to v7.7 (#202)

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -19,7 +19,7 @@
           &lt;commitId&gt;, etc.)
     - string:
         name: root_branch
-        default: 'v7.6'
+        default: 'v7.7'
         description: Which branch should also be available as the maps.elastic.co root
     node: linux && !oraclelinux
     scm:


### PR DESCRIPTION
Backports the following commits to v7.7:
 - Bump https://maps.elastic.co to v7.7 (#202)