### PR TITLE
Bump root to v7.8

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -19,7 +19,7 @@
           &lt;commitId&gt;, etc.)
     - string:
         name: root_branch
-        default: 'v7.7'
+        default: 'v7.8'
         description: Which branch should also be available as the maps.elastic.co root
     node: linux && !oraclelinux
     scm:


### PR DESCRIPTION
This bumps the root at https://maps.elastic.co for the v7.8 release per instructions in CONTRIBUTING.md.