### PR TITLE
[v7.8] Remove https redirector - no longer needed (#220)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ This script will put the relevant resources of the app in the `./build/release/*
 If any intermediate tasks break before packaging, such as a javascript linting or compilation failure, the build-script will error out.
 Fix the errors, and redeploy.
 
-## HTTPS
-By default, the client will redirect HTTP protocols to HTTPS. This can be disabled by setting the `httpOnly` environment variable, e.g. `httpOnly=YES yarn dev` or `httpOnly=YES yarn compile`.
-
 ## Continuous Integration and Deployment
 * When a PR is merged Jenkins will run `deployStaging.sh` script, which will place code into the staging bucket.
 * Deploying to production requires manually triggering [this Jenkins job](https://kibana-ci.elastic.co/job/elastic+ems-landing-page+deploy/) to run the [deployProduction.sh](deployProduction.sh) script. This will rsync files in all branches to the production bucket. To trigger, log in and click the "Build with Parameters" link.

--- a/public/index.hbs
+++ b/public/index.hbs
@@ -1,11 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  {{#if htmlWebpackPlugin.options.httpsRedirect}}
-    <script>if (location.protocol === 'http:' && location.hostname !== 'localhost')
-      location.href = location.href.replace(/^http:/, 'https:');
-    </script>
-  {{/if}}
     <meta charset="UTF-8">
     <title>Elastic Maps Service</title>
     <link rel="shortcut icon" href="./ems.png" />

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -79,7 +79,6 @@ module.exports = {
     new HTMLWebpackPlugin({
       template: 'public/index.hbs',
       hash: true,
-      httpsRedirect: 'httpOnly' in process.env ? false : true,
     }),
     new OptimizeCssAssetsPlugin()
   ],


### PR DESCRIPTION
Backports the following commits to v7.8:
 - Remove https redirector - no longer needed (#220)