### PR TITLE
Bump ems-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.2",
-    "@elastic/ems-client": "7.9.3",
+    "@elastic/ems-client": "7.9.4",
     "@elastic/eui": "^14.8.0",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,10 +887,10 @@
   dependencies:
     tslib "^1.9.3"
 
-"@elastic/ems-client@7.9.3":
-  version "7.9.3"
-  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.9.3.tgz#71b79914f76e347f050ead8474ad65d761e94a8a"
-  integrity sha512-aun5rW9TQgWLVH77xBLLhempT3P+6AeQIEyK/CWYuVfCDpHfDxzMKWgQ076a7rSUqF059ayDGZbyOxf7l0M2Sw==
+"@elastic/ems-client@7.9.4":
+  version "7.9.4"
+  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.9.4.tgz#4cc18690bb4cfcd1158016775e532c75ec277312"
+  integrity sha512-p66WPtP5M4lPtSmVz9+Asc+Xll0eofq/gAzqOnzbCs0oaGRtSlnJj4kOGkCuW3fx0voJpM85RuKOUuFtmYbjcw==
   dependencies:
     lodash "^4.17.15"
     semver "^6.3.0"


### PR DESCRIPTION
Bumps ems-client to 7.9.4

See https://github.com/elastic/ems-client/pull/46 and https://github.com/elastic/ems-landing-page/pull/228