### PR TITLE
Bump root to v7.9

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -19,7 +19,7 @@
           &lt;commitId&gt;, etc.)
     - string:
         name: root_branch
-        default: 'v7.8'
+        default: 'v7.9'
         description: Which branch should also be available as the maps.elastic.co root
     node: linux && !oraclelinux
     scm:


### PR DESCRIPTION
Now that 7.9 is released, https://maps.elastic.co should use the v7.9 manifest. 

Per instructions in [CONTRIBUTING.md](https://github.com/elastic/ems-landing-page/blob/master/CONTRIBUTING.md#new-releases). 