### PR TITLE
Download GeoJSON when available

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.2",
-    "@elastic/ems-client": "7.10.0",
+    "@elastic/ems-client": "7.11.0",
     "@elastic/eui": "^28.4.0",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.0.1",

--- a/public/js/components/feature_table.js
+++ b/public/js/components/feature_table.js
@@ -83,7 +83,7 @@ export class FeatureTable extends Component {
 
   _renderToolsRight() {
     let humanReadableFormat;
-    const format = this.props.config.getDefaultFormatType();
+    const format = this.props.config.getFormatOfType('geojson');
     if (format === 'geojson') {
       humanReadableFormat = 'GeoJSON';
     } else if (format === 'topojson') {
@@ -92,7 +92,7 @@ export class FeatureTable extends Component {
       humanReadableFormat = format;
     }
     return (
-      <EuiButton href={this.props.config.getDefaultFormatUrl()} target="_">
+      <EuiButton href={this.props.config.getFormatOfTypeUrl('geojson')} target="_">
         Download {humanReadableFormat}
       </EuiButton>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -886,10 +886,10 @@
   dependencies:
     tslib "^1.9.3"
 
-"@elastic/ems-client@7.10.0":
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.10.0.tgz#6d0e12ce99acd122d8066aa0a8685ecfd21637d3"
-  integrity sha512-84XqAhY4iaKwo2PnDwskNLvnprR3EYcS1AhN048xa8mIZlRJuycB4DwWnB699qvUTQqKcg5qLS0o5sEUs2HDeA==
+"@elastic/ems-client@7.11.0":
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.11.0.tgz#d2142d0ef5bd1aff7ae67b37c1394b73cdd48d8b"
+  integrity sha512-7+gDEkBr8nRS7X9i/UPg1WkS7bEBuNbBBjXCchQeYwqPRmw6vOb4wjlNzVwmOFsp2OH4lVFfZ+XU4pxTt32EXA==
   dependencies:
     lodash "^4.17.15"
     semver "7.3.2"


### PR DESCRIPTION
Fixes #255 

The "Download <format type>" button tries to get the "geojson" format of the layer. If a "geojson" format is unavailable, the default format type is used.

This requires https://github.com/elastic/ems-client/pull/53.