### PR TITLE
Build option to host under path other than root

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -12,6 +12,8 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const WebappWebpackPlugin = require('webapp-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
+const ASSET_PATH = process.env.ASSET_PATH || '/';
+
 module.exports = {
   entry: {
     mapbox: './node_modules/mapbox-gl/dist/mapbox-gl.js',
@@ -20,7 +22,8 @@ module.exports = {
   mode: 'development',
   output: {
     path: path.resolve(__dirname, 'build/release'),
-    filename: '[name].bundle.js'
+    filename: '[name].bundle.js',
+    publicPath: ASSET_PATH,
   },
   module: {
     noParse: /iconv-loader\.js/,


### PR DESCRIPTION
Currently, EMS landing page always expects assets to be available at the root web server path. It is currently not possible to load assets from a path other than `/`. We can see this by running `yarn build && npx http-server . -o /build/release` from the repo root directory. Note that all assets return 404 because they are expected to be available at `/` instead of relative to the current path. 

This PR introduces a `ASSET_PATH` environment variable that changes the webpack `[output.publicPath](https://webpack.js.org/configuration/output/#outputpublicpath)` variable. We can test this PR by running `ASSET_PATH=/build/release/ yarn build && npx http-server . -o /build/release` from the repo root directory.

Note, it's imperative to include a trailing slash when specifying the `ASSET_PATH`.