### PR TITLE
Use default publicPath if ASSET_PATH is not specified

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -12,7 +12,7 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const WebappWebpackPlugin = require('webapp-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
-const ASSET_PATH = process.env.ASSET_PATH || '/';
+const ASSET_PATH = process.env.ASSET_PATH || '';
 
 module.exports = {
   entry: {


### PR DESCRIPTION
#258 sets the wrong default for `[publicPath](https://webpack.js.org/configuration/output/#outputpublicpath)`. 😖 The default should be `''`, not `/`. You can see that the icons have disappeared in https://maps-staging.elastic.co/master. Hopefully this PR fixes that.