### PR TITLE
[v6.6] Use default publicPath if ASSET_PATH is not specified (#259)

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -11,7 +11,7 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const WebappWebpackPlugin = require('webapp-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
-const ASSET_PATH = process.env.ASSET_PATH || '/';
+const ASSET_PATH = process.env.ASSET_PATH || '';
 
 module.exports = {
   entry: {


### PR DESCRIPTION
Backports the following commits to v6.6:
 - Use default publicPath if ASSET_PATH is not specified (#259)