### PR TITLE
[v7.10] Bump root maps.elastic.co to v7.10 (#284)

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -19,7 +19,7 @@
           &lt;commitId&gt;, etc.)
     - string:
         name: root_branch
-        default: 'v7.9'
+        default: 'v7.10'
         description: Which branch should also be available as the maps.elastic.co root
     node: linux && !oraclelinux
     scm:


### PR DESCRIPTION
Backports the following commits to v7.10:
 - Bump root maps.elastic.co to v7.10 (#284)