### PR TITLE
Add details for currently selected tile layer

### DIFF
--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -34,6 +34,7 @@ export class App extends Component {
     super(props);
 
     this.state = {
+      selectedTileLayer: null,
       selectedFileLayer: null,
       jsonFeatures: null,
       initialSelection: null
@@ -81,6 +82,9 @@ export class App extends Component {
 
     this._selectTmsLayer = async (tmsLayerConfig) => {
       const source = await this._getTmsSource(tmsLayerConfig);
+      this.setState({
+        selectedTileLayer: tmsLayerConfig,
+      });
 
       this._map.setTmsLayer(source);
     };
@@ -206,7 +210,13 @@ export class App extends Component {
               <EuiSpacer size="xl" />
               <EuiPageContent>
                 <EuiPageContentBody>
-                  <LayerDetails layerConfig={this.state.selectedFileLayer} />
+                  <LayerDetails type="Tile Layer" layerConfig={this.state.selectedTileLayer} />
+                </EuiPageContentBody>
+              </EuiPageContent>
+              <EuiSpacer />
+              <EuiPageContent>
+                <EuiPageContentBody>
+                  <LayerDetails type="Vector Layer" layerConfig={this.state.selectedFileLayer} />
                   <EuiSpacer size="l" />
                   <FeatureTable
                     ref={setFeatureTable}

--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -210,13 +210,13 @@ export class App extends Component {
               <EuiSpacer size="xl" />
               <EuiPageContent>
                 <EuiPageContentBody>
-                  <LayerDetails type="Tile Layer" layerConfig={this.state.selectedTileLayer} />
+                  <LayerDetails title="Tile Layer" layerConfig={this.state.selectedTileLayer} />
                 </EuiPageContentBody>
               </EuiPageContent>
               <EuiSpacer />
               <EuiPageContent>
                 <EuiPageContentBody>
-                  <LayerDetails type="Vector Layer" layerConfig={this.state.selectedFileLayer} />
+                  <LayerDetails title="Vector Layer" layerConfig={this.state.selectedFileLayer} />
                   <EuiSpacer size="l" />
                   <FeatureTable
                     ref={setFeatureTable}

--- a/public/js/components/layer_details.js
+++ b/public/js/components/layer_details.js
@@ -24,9 +24,10 @@ export class LayerDetails extends PureComponent {
     return (
       <div>
         <EuiTitle size="s">
-          <h2>{this.props.layerConfig.getDisplayName()}</h2>
+          <h2>Selected {this.props.type}: {this.props.layerConfig.getDisplayName()}</h2>
         </EuiTitle>
         <EuiText size="s">
+          <p>Layer Id: {this.props.layerConfig.getId()}</p>
           <span dangerouslySetInnerHTML={{ __html: attributionsHtmlString }} className="attribution"/>
         </EuiText>
       </div>

--- a/public/js/components/layer_details.js
+++ b/public/js/components/layer_details.js
@@ -24,7 +24,7 @@ export class LayerDetails extends PureComponent {
     return (
       <div>
         <EuiTitle size="s">
-          <h2>Selected {this.props.type}: {this.props.layerConfig.getDisplayName()}</h2>
+          <h2>Selected {this.props.title}: {this.props.layerConfig.getDisplayName()}</h2>
         </EuiTitle>
         <EuiText size="s">
           <p>Layer Id: {this.props.layerConfig.getId()}</p>


### PR DESCRIPTION
Fixes #304. This adds a content pane for the currently selected tile layer. 

This also adds the `layer_id` for the currently selected layers in the UI.