### PR TITLE
Bump https://maps.elastic.co to 7.12

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -19,7 +19,7 @@
           &lt;commitId&gt;, etc.)
     - string:
         name: root_branch
-        default: 'v7.11'
+        default: 'v7.12'
         description: Which branch should also be available as the maps.elastic.co root
     node: linux && !oraclelinux
     scm:


### PR DESCRIPTION
This will bump https://maps.elastic.co to 7.12. 

Following the instructions in https://github.com/elastic/ems-landing-page/blob/master/CONTRIBUTING.md#new-releases.