### PR TITLE
[v7.12]  Bump https://maps.elastic.co to 7.12 (#311)

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -19,7 +19,7 @@
           &lt;commitId&gt;, etc.)
     - string:
         name: root_branch
-        default: 'v7.11'
+        default: 'v7.12'
         description: Which branch should also be available as the maps.elastic.co root
     node: linux && !oraclelinux
     scm:


### PR DESCRIPTION
Backports the following commits to v7.12:
 - Update defaults.yml (#311)