### PR TITLE
Allow configurable service name in header

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,5 +1,6 @@
 {
   "default": "production",
+  "serviceName": "Elastic Maps Server",
   "SUPPORTED_EMS": {
     "emsVersion": "v7.12",
     "manifest": {

--- a/public/config.json
+++ b/public/config.json
@@ -1,6 +1,6 @@
 {
   "default": "production",
-  "serviceName": "Elastic Maps Server",
+  "serviceName": "Elastic Maps Service",
   "SUPPORTED_EMS": {
     "emsVersion": "v7.12",
     "manifest": {

--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -184,7 +184,9 @@ export class App extends Component {
       <div>
         <EuiHeader>
           <EuiHeaderSectionItem border="right">
-            <EuiHeaderLogo href="#" aria-label="Go to elastic.co" iconType="emsApp" >Elastic Maps Service</EuiHeaderLogo>
+            <EuiHeaderLogo href="/" aria-label={`${this.props.serviceName} home`} iconType="emsApp" >
+              {this.props.serviceName}
+            </EuiHeaderLogo>
           </EuiHeaderSectionItem>
           <EuiHeaderSectionItem border="none">
             <EuiHeaderLinks gutterSize="xs">

--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -97,6 +97,8 @@ export class App extends Component {
 
   componentDidMount() {
 
+    document.title = this.props.serviceName;
+
     if (!Map.isSupported()) {
       return;
     }


### PR DESCRIPTION
Changes the header logo to allow a service name specified in the config file. Defaults to "Elastic Maps Service" when there is no service name specified.

*Note* this also changes the href to link to the root rather than an anchor link. This is useful when this page is hosted under a path such as in Elastic Maps Server. 