### PR TITLE
Bump dns-packet and EUI and switch to Amsterdam theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.2",
     "@elastic/ems-client": "7.13.0",
-    "@elastic/eui": "33.0.0",
+    "@elastic/eui": "34.1.0",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.0.1",
     "@turf/center": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.2",
     "@elastic/ems-client": "7.13.0",
-    "@elastic/eui": "34.1.0",
+    "@elastic/eui": "34.6.0",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.0.1",
     "@turf/center": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.2",
     "@elastic/ems-client": "7.13.0",
-    "@elastic/eui": "34.6.0",
+    "@elastic/eui": "36.0.0",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.0.1",
     "@turf/center": "6.0.1",

--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -200,7 +200,7 @@ export class App extends Component {
               <EuiPanel paddingSize="none">
                 <Map ref={setMap} />
               </EuiPanel>
-              <EuiSpacer size="xl" />
+              <EuiSpacer size="l" />
               <EuiPageContent>
                 <EuiPageContentBody>
                   <LayerDetails title="Tile Layer" layerConfig={this.state.selectedTileLayer} />

--- a/public/js/components/feature_table.js
+++ b/public/js/components/feature_table.js
@@ -122,11 +122,6 @@ export class FeatureTable extends Component {
       onChange: this._changeFilter
     };
 
-    const pagination = {
-      pageSize: 8,
-      pageSizeOptions: [50],
-    };
-
     const rowProps = (row) => {
       return {
         onClick: () => {
@@ -142,7 +137,7 @@ export class FeatureTable extends Component {
         items={rows}
         columns={columns}
         search={search}
-        pagination={pagination}
+        pagination={true}
         sorting
       />
     );

--- a/public/js/components/feature_table.js
+++ b/public/js/components/feature_table.js
@@ -123,7 +123,7 @@ export class FeatureTable extends Component {
     };
 
     const pagination = {
-      initialPageSize: 50,
+      pageSize: 8,
       pageSizeOptions: [50],
     };
 

--- a/public/js/components/layer_details.js
+++ b/public/js/components/layer_details.js
@@ -10,8 +10,7 @@ import React, { PureComponent } from 'react';
 import {
   EuiText,
   EuiTitle,
-  EuiBadge,
-  EuiSpacer
+  EuiBadge
 } from '@elastic/eui';
 
 export class LayerDetails extends PureComponent {
@@ -23,16 +22,15 @@ export class LayerDetails extends PureComponent {
     if (!this.props.layerConfig) {
       return null;
     }
-    const attributionsHtmlString = getAttributionString(this.props.layerConfig);
+    const attributionsHtmlString = 'Attribution: ' + getAttributionString(this.props.layerConfig);
     return (
       <div>
-        <EuiTitle size="s">
+        <EuiTitle size="s" className="layerTitle">
           <h2>Selected {this.props.title}: {this.props.layerConfig.getDisplayName()}</h2>
         </EuiTitle>
         <EuiText size="s">
           <EuiBadge>Layer Id: {this.props.layerConfig.getId()}</EuiBadge>
-          <EuiSpacer size="xs" />
-          <span dangerouslySetInnerHTML={{ __html: attributionsHtmlString }} className="attribution"/>
+          <span dangerouslySetInnerHTML={{ __html: attributionsHtmlString }} className="attribution eui-alignMiddle"/>
         </EuiText>
       </div>
     );

--- a/public/main.css
+++ b/public/main.css
@@ -36,7 +36,7 @@ body {
 .euiSideNavItem__items {
     overflow-x: hidden;
     overflow-y: auto;
-    max-height: 1020px;
+    max-height: 1120px;
 }
 
 .euiPage--paddingMedium .euiPageSideBar {

--- a/public/main.css
+++ b/public/main.css
@@ -1,4 +1,4 @@
-@import "../node_modules/@elastic/eui/dist/eui_theme_light.css";
+@import "../node_modules/@elastic/eui/dist/eui_theme_amsterdam_light.css";
 @import "../node_modules/mapbox-gl/dist/mapbox-gl.css";
 
 body {
@@ -9,34 +9,24 @@ body {
     width: 100%;
 }
 
-
 .mainContent {
     width: 100%;
 }
 
 .mapContainer {
     width: 100%;
-    height: 512px;
+    height: 450px;
 }
 
-.attribution  p {
-    display: inline;
+.layerTitle {
+    margin-bottom: 5px;
 }
-
+.attribution  {
+    margin-left: 10px; 
+}
 
 /* The following will need to be fixed in EUI too */
-.euiHeader {
-    position: relative;
-    z-index: 2000;
-}
 
-.euiHeaderLinks {
-    position: static;
-}
-
-.euiHeaderSectionItem:hover {
-    background: transparent;
-}
 
 .mapboxgl-popup-close-button {
     padding-left: 7px;
@@ -47,4 +37,13 @@ body {
     overflow-x: hidden;
     overflow-y: auto;
     max-height: 1020px;
+}
+
+.euiPage--paddingMedium .euiPageSideBar {
+    min-width: 220px;
+}
+
+.euiSideNavItem--root.euiSideNavItem--rootIcon 
+> .euiSideNavItem__items {
+    margin-left: 10px;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3865,9 +3865,9 @@ dns-equal@^1.0.0:
   integrity sha1-s55/HabrCnW6nBcySzR1PEfgZU0=
 
 dns-packet@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.1.tgz#12aa426981075be500b910eedcd0b47dd7deda5a"
-  integrity sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.4.tgz#e3455065824a2507ba886c55a89963bb107dec6f"
+  integrity sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==
   dependencies:
     ip "^1.1.0"
     safe-buffer "^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,10 +977,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-config-kibana/-/eslint-config-kibana-0.15.0.tgz#a552793497cdfc1829c2f9b7cd7018eb008f1606"
   integrity sha1-pVJ5NJfN/Bgpwvm3zXAY6wCPFgY=
 
-"@elastic/eui@34.6.0":
-  version "34.6.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-34.6.0.tgz#a7188bc97d9c3120cd65e52ed423377872b604bd"
-  integrity sha512-uVMSX0jPJU3LLwD4TRHllyJeTr+Uihh+R5qsFSAzKrCCRZjSfKMmMHKffWhzFyYjG97npdWlMvneXG5q0yobCw==
+"@elastic/eui@36.0.0":
+  version "36.0.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-36.0.0.tgz#ebb180e859fd86171b5f84d08f8c958bb659b1cd"
+  integrity sha512-VLwtHZp3Qdj+vWR8wSNwxEYpGtJIdiErq0/PBsg83HDfz4KwgEveSI6STwODLgiUDr/YnpDhawuz+HU3JpfXRg==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,10 +977,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-config-kibana/-/eslint-config-kibana-0.15.0.tgz#a552793497cdfc1829c2f9b7cd7018eb008f1606"
   integrity sha1-pVJ5NJfN/Bgpwvm3zXAY6wCPFgY=
 
-"@elastic/eui@34.1.0":
-  version "34.1.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-34.1.0.tgz#215c642077b5946c175929772b3534353aa65bea"
-  integrity sha512-EBoM2j8oCwH6VWNYWzHXE619yglrQrPXtOGdZZk21Bh2/QsnvVc3F78nNzLWLzncTHYrYH7eUVUaCZW7hLT7hg==
+"@elastic/eui@34.6.0":
+  version "34.6.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-34.6.0.tgz#a7188bc97d9c3120cd65e52ed423377872b604bd"
+  integrity sha512-uVMSX0jPJU3LLwD4TRHllyJeTr+Uihh+R5qsFSAzKrCCRZjSfKMmMHKffWhzFyYjG97npdWlMvneXG5q0yobCw==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"
@@ -995,6 +995,7 @@
     chroma-js "^2.1.0"
     classnames "^2.2.6"
     lodash "^4.17.21"
+    mdast-util-to-hast "^10.0.0"
     numeral "^2.0.6"
     prop-types "^15.6.0"
     react-ace "^7.0.5"
@@ -1005,7 +1006,7 @@
     react-is "~16.3.0"
     react-virtualized-auto-sizer "^1.0.2"
     react-window "^1.8.5"
-    refractor "^3.3.1"
+    refractor "^3.4.0"
     rehype-raw "^5.0.0"
     rehype-react "^6.0.0"
     rehype-stringify "^8.0.0"
@@ -1015,6 +1016,7 @@
     tabbable "^3.0.0"
     text-diff "^1.0.1"
     unified "^9.2.0"
+    unist-util-visit "^2.0.3"
     url-parse "^1.5.0"
     uuid "^8.3.0"
     vfile "^4.2.0"
@@ -3016,15 +3018,6 @@ cli-width@^3.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
-clipboard@^2.0.0:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.8.tgz#ffc6c103dd2967a83005f3f61976aa4655a4cdba"
-  integrity sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==
-  dependencies:
-    good-listener "^1.2.2"
-    select "^1.1.2"
-    tiny-emitter "^2.0.0"
-
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
@@ -3789,11 +3782,6 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-
-delegate@^3.1.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
-  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -5166,13 +5154,6 @@ globule@^1.0.0:
     glob "~7.1.1"
     lodash "~4.17.10"
     minimatch "~3.0.2"
-
-good-listener@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
-  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
-  dependencies:
-    delegate "^3.1.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
   version "4.2.6"
@@ -6749,7 +6730,7 @@ mdast-util-definitions@^4.0.0:
   dependencies:
     unist-util-visit "^2.0.0"
 
-mdast-util-to-hast@^10.2.0:
+mdast-util-to-hast@^10.0.0, mdast-util-to-hast@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz#61875526a017d8857b71abc9333942700b2d3604"
   integrity sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==
@@ -8309,12 +8290,10 @@ pretty-error@^2.0.2:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-prismjs@~1.23.0:
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
-  integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==
-  optionalDependencies:
-    clipboard "^2.0.0"
+prismjs@~1.24.0:
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.24.1.tgz#c4d7895c4d6500289482fa8936d9cdd192684036"
+  integrity sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==
 
 private@^0.1.8, private@~0.1.5:
   version "0.1.8"
@@ -8817,14 +8796,14 @@ redux@^4.0.0, redux@^4.0.4:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
-refractor@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.3.1.tgz#ebbc04b427ea81dc25ad333f7f67a0b5f4f0be3a"
-  integrity sha512-vaN6R56kLMuBszHSWlwTpcZ8KTMG6aUCok4GrxYDT20UIOXxOc5o6oDc8tNTzSlH3m2sI+Eu9Jo2kVdDcUTWYw==
+refractor@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.4.0.tgz#62bd274b06c942041f390c371b676eb67cb0a678"
+  integrity sha512-dBeD02lC5eytm9Gld2Mx0cMcnR+zhSnsTfPpWqFaMgUMJfC9A6bcN3Br/NaXrnBJcuxnLFR90k1jrkaSyV8umg==
   dependencies:
     hastscript "^6.0.0"
     parse-entities "^2.0.0"
-    prismjs "~1.23.0"
+    prismjs "~1.24.0"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
@@ -9303,11 +9282,6 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
-
-select@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
-  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
 
 selfsigned@^1.10.8:
   version "1.10.11"
@@ -10226,11 +10200,6 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
-
-tiny-emitter@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
-  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
 tiny-invariant@^1.0.6:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,10 +977,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-config-kibana/-/eslint-config-kibana-0.15.0.tgz#a552793497cdfc1829c2f9b7cd7018eb008f1606"
   integrity sha1-pVJ5NJfN/Bgpwvm3zXAY6wCPFgY=
 
-"@elastic/eui@33.0.0":
-  version "33.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-33.0.0.tgz#525cf5ea6e6ab16c32bb09766e9c23806640240f"
-  integrity sha512-BQ6GJxKVaOF7Fm+IvH2iFeeGnepzygDr4xmmZ8PH2BEfrtkxzGP9YDpqmr/Drg5beVynJ3+72k1AEQT/JE6NTw==
+"@elastic/eui@34.1.0":
+  version "34.1.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-34.1.0.tgz#215c642077b5946c175929772b3534353aa65bea"
+  integrity sha512-EBoM2j8oCwH6VWNYWzHXE619yglrQrPXtOGdZZk21Bh2/QsnvVc3F78nNzLWLzncTHYrYH7eUVUaCZW7hLT7hg==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"


### PR DESCRIPTION
Fixes #354
Fixes #302

This PR upgrades to the last EUI version and adds some minor visual changes to accommodate better the layer details and the feature table.

This PR should only be merged once we are sure Kibana gets Amsterdam as default theme by backporting this PR elastic/kibana#94370 to the release branch.

![image](https://user-images.githubusercontent.com/188264/119849537-00924c80-bf0d-11eb-83ac-85ecdb8b303c.png)


