### PR TITLE
Change to 8.0 as the default branch to deploy

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -19,7 +19,7 @@
           &lt;commitId&gt;, etc.)
     - string:
         name: root_branch
-        default: 'v7.12'
+        default: 'v8.0'
         description: Which branch should also be available as the maps.elastic.co root
     node: linux && !oraclelinux
     scm:


### PR DESCRIPTION
Deploy the `8.0` branch as the default to be rendered at `maps.elastic.co`
