### PR TITLE
Reduce output assets number

### DIFF
--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -22,6 +22,25 @@ import {
   EuiToast
 } from '@elastic/eui';
 
+import { appendIconComponentCache } from '@elastic/eui/es/components/icon/icon';
+
+import { icon as EuiIconEmsApp } from '@elastic/eui/lib/components/icon/assets/app_ems';
+import { icon as EuiIconAlert } from '@elastic/eui/lib/components/icon/assets/alert';
+import { icon as EuiIconGithub } from '@elastic/eui/lib/components/icon/assets/logo_github';
+import { icon as EuiIconElastic } from '@elastic/eui/lib/components/icon/assets/logo_elastic';
+import { icon as EuiIconBug } from '@elastic/eui/lib/components/icon/assets/bug';
+import { icon as EuiIconDocuments } from '@elastic/eui/lib/components/icon/assets/documents';
+
+// One or more icons are passed in as an object of iconKey (string): IconComponent
+appendIconComponentCache({
+  emsApp: EuiIconEmsApp,
+  alert: EuiIconAlert,
+  logoGithub: EuiIconGithub,
+  logoElastic: EuiIconElastic,
+  bug: EuiIconBug,
+  documents: EuiIconDocuments,
+});
+
 import { TableOfContents } from './table_of_contents';
 import { FeatureTable } from './feature_table';
 import { Map } from './map';

--- a/public/js/components/table_of_contents.js
+++ b/public/js/components/table_of_contents.js
@@ -13,6 +13,24 @@ import {
   EuiSideNav,
 } from '@elastic/eui';
 
+import { appendIconComponentCache } from '@elastic/eui/es/components/icon/icon';
+
+import { icon as EuiIconGrid } from '@elastic/eui/lib/components/icon/assets/grid';
+import { icon as EuiIconVector } from '@elastic/eui/lib/components/icon/assets/vector';
+import { icon as EuiIconSearch } from '@elastic/eui/es/components/icon/assets/search';
+import { icon as EuiIconArrowDown } from '@elastic/eui/es/components/icon/assets/arrow_down';
+import { icon as EuiIconArrowLeft } from '@elastic/eui/es/components/icon/assets/arrow_left';
+import { icon as EuiIconArrowRight } from '@elastic/eui/es/components/icon/assets/arrow_right';
+
+// One or more icons are passed in as an object of iconKey (string): IconComponent
+appendIconComponentCache({
+  grid: EuiIconGrid,
+  vector: EuiIconVector,
+  search: EuiIconSearch,
+  arrowDown: EuiIconArrowDown,
+  arrowLeft: EuiIconArrowLeft,
+  arrowRight: EuiIconArrowRight,
+});
 
 export class TableOfContents extends Component {
   constructor(props) {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -11,6 +11,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HTMLWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 
 const ASSET_PATH = process.env.ASSET_PATH || '';
 
@@ -76,7 +77,11 @@ module.exports = {
     },
   },
   plugins: [
-    new CleanWebpackPlugin(),
+    new CleanWebpackPlugin({
+      cleanAfterEveryBuildPatterns: [
+        path.resolve(__dirname, 'build/release/icon*')
+      ]
+    }),
     new CopyWebpackPlugin({
       patterns: [
         { from: './public/config.json', to: '.' }
@@ -86,7 +91,21 @@ module.exports = {
       template: 'public/index.hbs',
       hash: true,
     }),
-    new OptimizeCssAssetsPlugin()
+    new OptimizeCssAssetsPlugin(),
+    new FaviconsWebpackPlugin({
+      logo: './public/app_ems.svg',
+      favicons: {
+        icons: {
+          coast: false,
+          yandex: false,
+          android: false,
+          appleIcon: false,
+          appleStartup: false,
+          windows: false,
+          firefox: false
+        }
+      }
+    }),
   ],
   stats: {
     colors: true

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -7,7 +7,6 @@
 
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
-const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 
 module.exports = merge(common, {
   mode: 'development',
@@ -15,7 +14,5 @@ module.exports = merge(common, {
   devServer: {
     contentBase: './public'
   },
-  plugins: [
-    new FaviconsWebpackPlugin('./public/app_ems.svg'),
-  ]
+  plugins: []
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -7,12 +7,10 @@
 
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
-const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
+
 
 module.exports = merge(common, {
   mode: 'production',
   devtool: 'source-map',
-  plugins: [
-    new FaviconsWebpackPlugin('./public/app_ems.svg'),
-  ]
+  plugins: [],
 });


### PR DESCRIPTION
Fixes #227

Using `appendIconComponentCache` function in EUI we can inline icons so we can safely remove the individual icon bundles generated by webpack with the `cleanAfterEveryBuildPatterns` option from the `CleanWebpackPlugin` (in Webpack 5 this won't be necessary as it's supported directly with the `output.clean` option).

Also, the `FaviconsWebpackPlugin` is configured to skip generating icons for different mobile platforms cleaning the resulting HTML and the `assets` folder.
