### PR TITLE
Allow to build from node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
   "author": "Elastic",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {
-    "node": ">=14 <=16"
+    "node": ">=12 <=16"
   }
 }


### PR DESCRIPTION
Since it is compatible, and following the same pattern as in [EMS File Service](https://github.com/elastic/ems-file-service/blob/master/package.json#L13), we can allow systems with Node 12 to build the page.
