### PR TITLE
[v7.16] Allow to build from node 12 (#395)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
   "author": "Elastic",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {
-    "node": ">=14 <=16"
+    "node": ">=12 <=16"
   }
 }


### PR DESCRIPTION
Backports the following commits to v7.16:
 - Allow to build from node 12 (#395)