### PR TITLE
[v7.17] Bump moment from 2.29.1 to 2.29.2 (#425)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@turf/bbox": "6.5.0",
     "@turf/center": "6.5.0",
     "maplibre-gl": ">=1.14.0",
-    "moment": "2.29.1",
+    "moment": "2.29.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "url-parse": "1.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6995,10 +6995,10 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@2.29.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+moment@2.29.2:
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
+  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This is an automatic backport of pull request #425 to v7.17.

Please refer to the [Backport tool documentation](https://github.com/sqren/backport) for additional information