### PR TITLE
[v8.4] Bump to 8.4.0 (#436)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,8 @@
 {
   "upstream": "elastic/ems-landing-page",
   "branches": [
+    { "name": "v8.4", "checked":  true },
+    { "name": "v8.3", "checked":  true },
     { "name": "v8.2", "checked":  true },
     { "name": "v8.1", "checked":  true },
     { "name": "v8.0", "checked":  true },

--- a/.ci/jobs/elastic+ems-landing-page+v8.4.yml
+++ b/.ci/jobs/elastic+ems-landing-page+v8.4.yml
@@ -1,0 +1,30 @@
+---
+- job:
+    name: elastic+ems-landing-page+v8.4+stage
+    display-name: 'elastic / ems-landing-page # v8.4 - stage'
+    description: Build and deploy v8.4 branch to staging server using ./deployStaging.sh.
+    parameters:
+    - string:
+        name: branch_specifier
+        default: refs/heads/v8.4
+        description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
+          &lt;commitId&gt;, etc.)
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -e
+        set +x
+
+        export ROOT_BRANCH=$root_branch
+        export GPROJECT=elastic-bekitzur
+        VAULT_ACCOUNT=secret/gce/$GPROJECT/service-account/maps-landing
+
+        VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        GCE_ACCOUNT=$(vault read -field=value $VAULT_ACCOUNT)
+        export GCE_ACCOUNT
+        unset VAULT_ROLE_ID VAULT_SECRET_ID VAULT_ADDR VAULT_TOKEN VAULT_ACCOUNT
+
+        # Expects env: GPROJECT, GCE_ACCOUNT, GIT_BRANCH, ROOT_BRANCH
+        # Run EMS script, set in the template parameter
+        ./deployStaging.sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ems_landing_page",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "",
   "main": "main.js",
   "devDependencies": {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.4`:
 - [Bump to 8.4.0 (#436)](https://github.com/elastic/ems-landing-page/pull/436)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)