### PR TITLE
Set 8.3 as the root default

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -19,7 +19,7 @@
           &lt;commitId&gt;, etc.)
     - string:
         name: root_branch
-        default: 'v8.2'
+        default: 'v8.3'
         description: Which branch should also be available as the maps.elastic.co root
     node: linux && !oraclelinux
     scm:


### PR DESCRIPTION
Updates the default branch to be deployed at maps.elastic.co to `v8.3`
