### PR TITLE
Vector tiles from .dev when manifest query param is testing

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -6,7 +6,7 @@
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",
-        "emsTileApiUrl": "https://tiles.maps.elastic.co"
+        "emsTileApiUrl": "https://tiles.maps.elastic.dev"
       },
       "staging": {
         "emsFileApiUrl": "https://vector-staging.maps.elastic.co",


### PR DESCRIPTION
Changing to `tiles.elastic.dev` for `manifest=testing`.

This will help to review basemaps refreshes before going to production.
