### PR TITLE
[v8.6] Getting our vector tiles from dev domain when manifest is set to testing (#452) | Update backport config to 8.5 and 8.6 (#454) | Set 8.4 as the root default (#455) | Include a fullscreen control on the map (#453)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,11 +1,13 @@
 {
   "upstream": "elastic/ems-landing-page",
   "branches": [
+    { "name": "v8.6", "checked":  true },
+    { "name": "v8.5", "checked":  true },
     { "name": "v8.4", "checked":  true },
-    { "name": "v8.3", "checked":  true },
-    { "name": "v8.2", "checked":  true },
-    { "name": "v8.1", "checked":  true },
-    { "name": "v8.0", "checked":  true },
+    { "name": "v8.3", "checked":  false },
+    { "name": "v8.2", "checked":  false },
+    { "name": "v8.1", "checked":  false },
+    { "name": "v8.0", "checked":  false },
     { "name": "v7.17", "checked":  false },
     { "name": "v7.16", "checked":  false },
     { "name": "v7.15", "checked":  false }

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -19,7 +19,7 @@
           &lt;commitId&gt;, etc.)
     - string:
         name: root_branch
-        default: 'v8.3'
+        default: 'v8.4'
         description: Which branch should also be available as the maps.elastic.co root
     node: linux && !oraclelinux
     scm:

--- a/public/config.json
+++ b/public/config.json
@@ -6,7 +6,7 @@
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",
-        "emsTileApiUrl": "https://tiles.maps.elastic.co"
+        "emsTileApiUrl": "https://tiles.maps.elastic.dev"
       },
       "staging": {
         "emsFileApiUrl": "https://vector-staging.maps.elastic.co",

--- a/public/js/components/map.js
+++ b/public/js/components/map.js
@@ -44,6 +44,9 @@ export class Map extends Component {
         return { url: new URL(url, window.location.origin).href };
       },
     });
+
+    this._maplibreMap.addControl(new maplibre.FullscreenControl());
+
     this._maplibreMap.dragRotate.disable();
     this._maplibreMap.touchZoomRotate.disableRotation();
 

--- a/public/main.css
+++ b/public/main.css
@@ -47,3 +47,14 @@ body {
 > .euiSideNavItem__items {
     margin-left: 10px;
 }
+
+/* Harcode the EUI icon, instead of maplibre default */
+.mapboxgl-ctrl button.mapboxgl-ctrl-fullscreen .mapboxgl-ctrl-icon, .maplibregl-ctrl button.maplibregl-ctrl-fullscreen .maplibregl-ctrl-icon
+{
+    background-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='16' height='16' viewBox='0 0 16 16'%3E%3Cg fill-rule='evenodd'%3E%3Cpath d='M13,3 L13,7 L12,7 L12,4 L9,4 L9,3 L13,3 Z M3,3 L7,3 L7,4 L4,4 L4,7 L3,7 L3,3 Z M13,13 L9,13 L9,12 L12,12 L12,9 L13,9 L13,13 Z M3,13 L3,9 L4,9 L4,12 L7,12 L7,13 L3,13 Z M0,1.99406028 C0,0.892771196 0.894513756,0 1.99406028,0 L14.0059397,0 C15.1072288,0 16,0.894513756 16,1.99406028 L16,14.0059397 C16,15.1072288 15.1054862,16 14.0059397,16 L1.99406028,16 C0.892771196,16 0,15.1054862 0,14.0059397 L0,1.99406028 Z M1,1.99406028 L1,14.0059397 C1,14.5539384 1.44579254,15 1.99406028,15 L14.0059397,15 C14.5539384,15 15,14.5542075 15,14.0059397 L15,1.99406028 C15,1.44606163 14.5542075,1 14.0059397,1 L1.99406028,1 C1.44606163,1 1,1.44579254 1,1.99406028 Z'/%3E%3C/g%3E%3C/svg%3E%0A");
+}
+
+.mapboxgl-ctrl button.mapboxgl-ctrl-shrink .mapboxgl-ctrl-icon, .maplibregl-ctrl button.maplibregl-ctrl-shrink .maplibregl-ctrl-icon
+{
+    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg' class='euiIcon eui-alignMiddle css-1h0bwsh-euiIcon-m-isLoaded' role='img' data-icon-type='fullScreenExit' data-is-loaded='true' aria-hidden='true'%3E%3Cpath d='M9 7V3h1v3h3v1H9zM7 7H3V6h3V3h1v4zm2 2h4v1h-3v3H9V9zM7 9v4H6v-3H3V9h4zM0 1.994C0 .893.895 0 1.994 0h12.012C15.107 0 16 .895 16 1.994v12.012A1.995 1.995 0 0114.006 16H1.994A1.995 1.995 0 010 14.006V1.994zm1 0v12.012c0 .548.446.994.994.994h12.012a.995.995 0 00.994-.994V1.994A.995.995 0 0014.006 1H1.994A.995.995 0 001 1.994z'%3E%3C/path%3E%3C/svg%3E");
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.6`:
 - [Getting our vector tiles from dev domain when manifest is set to testing (#452)](https://github.com/elastic/ems-landing-page/pull/452)
 - [Update backport config to 8.5 and 8.6 (#454)](https://github.com/elastic/ems-landing-page/pull/454)
 - [Set 8.4 as the root default (#455)](https://github.com/elastic/ems-landing-page/pull/455)
 - [Include a fullscreen control on the map (#453)](https://github.com/elastic/ems-landing-page/pull/453)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)