### PR TITLE
[v8.6] Use desaturated map as the default (#458)

### DIFF
--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -176,7 +176,7 @@ export class App extends Component {
     }
 
     const baseLayer = this.props.layers.tms.find((service) => {
-      return service.getId() === 'road_map';
+      return service.getId() === 'road_map_desaturated';
     });
     this._toc.selectItem(`tms/${baseLayer.getId()}`, baseLayer);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.6`:
 - [Use desaturated map as the default (#458)](https://github.com/elastic/ems-landing-page/pull/458)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)