### PR TITLE
[v8.6] Bump qs from 6.5.2 to 6.5.3 (#479) | fix: upgrade @elastic/eui from 70.2.0 to 70.2.1 (#478) | Bump decode-uri-component from 0.2.0 to 0.2.2 (#477)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
     "@elastic/ems-client": "8.3.3",
-    "@elastic/eui": "70.2.0",
+    "@elastic/eui": "70.2.1",
     "@emotion/css": "^11.10.5",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8485,9 +8485,9 @@ qs@6.9.7:
   integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
 
 qs@~6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 querystring-es3@^0.2.0:
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3968,9 +3968,9 @@ decamelize@^1.2.0:
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 decompress-response@^4.2.0:
   version "4.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1053,10 +1053,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-config-kibana/-/eslint-config-kibana-0.15.0.tgz#a552793497cdfc1829c2f9b7cd7018eb008f1606"
   integrity sha1-pVJ5NJfN/Bgpwvm3zXAY6wCPFgY=
 
-"@elastic/eui@70.2.0":
-  version "70.2.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-70.2.0.tgz#69577096bdfa9ccc659e0185875201306d904f4d"
-  integrity sha512-ahFm00woxJIfmLyBp3cA46VB9Swl+kRczDhaH8bOpQhkfPimvHUwAPnPAJpZnYfcbqJh31NllHuDlRYnZ0IPng==
+"@elastic/eui@70.2.1":
+  version "70.2.1"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-70.2.1.tgz#bf1db285149a8154574cd2a999dd286f8c996150"
+  integrity sha512-S6uWzFB+VLFJ+8svJKZMxizE4dbEHJfFdESigpFfqHYUudN22Z2COYazDKDQzFjvNgV+YkgBgihKQrEthmLGpg==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.6`:
 - [Bump qs from 6.5.2 to 6.5.3 (#479)](https://github.com/elastic/ems-landing-page/pull/479)
 - [fix: upgrade @elastic/eui from 70.2.0 to 70.2.1 (#478)](https://github.com/elastic/ems-landing-page/pull/478)
 - [Bump decode-uri-component from 0.2.0 to 0.2.2 (#477)](https://github.com/elastic/ems-landing-page/pull/477)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)