### PR TITLE
[v8.7] fix: upgrade @elastic/eui from 70.3.0 to 70.4.0 (#488)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
     "@elastic/ems-client": "8.3.3",
-    "@elastic/eui": "70.3.0",
+    "@elastic/eui": "70.4.0",
     "@emotion/css": "^11.10.5",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1053,10 +1053,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-config-kibana/-/eslint-config-kibana-0.15.0.tgz#a552793497cdfc1829c2f9b7cd7018eb008f1606"
   integrity sha1-pVJ5NJfN/Bgpwvm3zXAY6wCPFgY=
 
-"@elastic/eui@70.3.0":
-  version "70.3.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-70.3.0.tgz#a428aea2f944fb87439eb90f74f2574061b97685"
-  integrity sha512-TKQP/JumUG9JCQycYwQ+sQRfpVf3OTShEfsUHeLVSK9yTE+0tdtb5aNIEFvTvsEGnvEMnWHDlCwsYJhyXJTwLw==
+"@elastic/eui@70.4.0":
+  version "70.4.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-70.4.0.tgz#0ce7520ac96e137f05861224a6cd0a029c4dc0bc"
+  integrity sha512-w/pMxC0drBtzy3RQzHBLLbKRgy4EUTSetej0eg7m87copRZOwWXqlrIt52uuUj9txenxmpSonnnvSB+1a7fCfg==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.7`:
 - [fix: upgrade @elastic/eui from 70.3.0 to 70.4.0 (#488)](https://github.com/elastic/ems-landing-page/pull/488)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)