### PR TITLE
Set 8.7 as supported EMS Version

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -2,7 +2,7 @@
   "default": "production",
   "serviceName": "Elastic Maps Service",
   "SUPPORTED_EMS": {
-    "emsVersion": "v8.6",
+    "emsVersion": "v8.7",
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",


### PR DESCRIPTION
Sets 8.7 as the EMS version to point API resources.

Leaving the 8.6 as the default for the root of <maps.elastic.co> until release.