### PR TITLE
[v8.7] Set 8.7 as supported EMS Version (#514)

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -2,7 +2,7 @@
   "default": "production",
   "serviceName": "Elastic Maps Service",
   "SUPPORTED_EMS": {
-    "emsVersion": "v8.6",
+    "emsVersion": "v8.7",
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.7`:
 - [Set 8.7 as supported EMS Version (#514)](https://github.com/elastic/ems-landing-page/pull/514)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)