### PR TITLE
Fix build node image and GCP bukect sync

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-NODE_IMG="node:gallium"
+NODE_IMG="node:hydrogen"
 
 # Compile using node image
 echo "Compiling ${PWD} using ${NODE_IMG} docker image"

--- a/deployStaging.sh
+++ b/deployStaging.sh
@@ -81,7 +81,8 @@ else
     echo "Sync $PWD/release/* to gs://$STAGING_BUCKET/$BRANCH/"
     gsutil -m rsync -d -r -a public-read -j js,css,html "$PWD/build/release/" "gs://$STAGING_BUCKET/$BRANCH/"
 
-    # If the branch name matches ROOT_BRANCH, it also gets copied to the root
+    # If the branch name matches ROOT_BRANCH, it also gets synced to the root
+    # excluding paths matching other versions to avoid removing them (v2, v7.x, etc.)
     if [[ "$BRANCH" == "$ROOT_BRANCH" ]]; then
         echo "Sync $PWD/release/* to gs://$STAGING_BUCKET/"
         gsutil -m rsync -d -r -a public-read -j js,css,html  -x '^v[\d.]+\/.*$' "$PWD/build/release/" "gs://$STAGING_BUCKET/"

--- a/deployStaging.sh
+++ b/deployStaging.sh
@@ -78,13 +78,13 @@ else
 
     # The trailing slash is critical with the branch.
     # Otherwise, files from subdirs will go to the same destination dir.
-    echo "Copying $PWD/release/* to gs://$STAGING_BUCKET/$BRANCH/"
+    echo "Sync $PWD/release/* to gs://$STAGING_BUCKET/$BRANCH/"
     gsutil -m rsync -d -r -a public-read -j js,css,html "$PWD/build/release/" "gs://$STAGING_BUCKET/$BRANCH/"
 
     # If the branch name matches ROOT_BRANCH, it also gets copied to the root
     if [[ "$BRANCH" == "$ROOT_BRANCH" ]]; then
-        echo "Copying $PWD/release/* to gs://$STAGING_BUCKET/"
-        gsutil -m rsync -d -r -a public-read -j js,css,html "$PWD/build/release/" "gs://$STAGING_BUCKET/"
+        echo "Sync $PWD/release/* to gs://$STAGING_BUCKET/"
+        gsutil -m rsync -d -r -a public-read -j js,css,html  -x '^v[\d.]+\/.*$' "$PWD/build/release/" "gs://$STAGING_BUCKET/"
     fi
 
 fi


### PR DESCRIPTION
Fixing a couple of issues related to EMS Landing Page build

- Update the build script to use node 18 docker image
- Add exclude pattern for rsync to the root branch

About the second, to validate that the exclusion regex on the `rsync`  command works as expected, I run something similar to this on a python environment:

```
>>> import re
>>> 
>>> tests = [
...     'index.html', 'assets/index.html',
...     'vsomething', 'vsomething/something',
...     'v2/index.html', 'v7.0/index.html',
...     'v7.17/index.html',
... ]
>>> 
>>> for test in tests:
...   search = re.search('^v[\d.]+\/.*$',test)
...   result = "❌" if search else "✅"
...   print(f"{result} {test}")
... 
✅ index.html
✅ assets/index.html
✅ vsomething
✅ vsomething/something
❌ v2/index.html
❌ v7.0/index.html
❌ v7.17/index.html
>>>
```

Then I also checked running the commands from my environment against testing buckets in our development GCP project, executing first the sync to copy the current build to different folders like `v2`, `v7.1`, `v7.17`, `removeme` and then executing the sync with the pattern exclusion to confirm that only the `removeme` folder was affected.
