### PR TITLE
[v8.6] Fix build node image and GCP bukect sync (#522)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-NODE_IMG="node:gallium"
+NODE_IMG="node:hydrogen"
 
 # Compile using node image
 echo "Compiling ${PWD} using ${NODE_IMG} docker image"

--- a/deployStaging.sh
+++ b/deployStaging.sh
@@ -78,13 +78,14 @@ else
 
     # The trailing slash is critical with the branch.
     # Otherwise, files from subdirs will go to the same destination dir.
-    echo "Copying $PWD/release/* to gs://$STAGING_BUCKET/$BRANCH/"
+    echo "Sync $PWD/release/* to gs://$STAGING_BUCKET/$BRANCH/"
     gsutil -m rsync -d -r -a public-read -j js,css,html "$PWD/build/release/" "gs://$STAGING_BUCKET/$BRANCH/"
 
-    # If the branch name matches ROOT_BRANCH, it also gets copied to the root
+    # If the branch name matches ROOT_BRANCH, it also gets synced to the root
+    # excluding paths matching other versions to avoid removing them (v2, v7.x, etc.)
     if [[ "$BRANCH" == "$ROOT_BRANCH" ]]; then
-        echo "Copying $PWD/release/* to gs://$STAGING_BUCKET/"
-        gsutil -m rsync -d -r -a public-read -j js,css,html "$PWD/build/release/" "gs://$STAGING_BUCKET/"
+        echo "Sync $PWD/release/* to gs://$STAGING_BUCKET/"
+        gsutil -m rsync -d -r -a public-read -j js,css,html  -x '^v[\d.]+\/.*$' "$PWD/build/release/" "gs://$STAGING_BUCKET/"
     fi
 
 fi


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.6`:
 - [Fix build node image and GCP bukect sync (#522)](https://github.com/elastic/ems-landing-page/pull/522)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)