### PR TITLE
Bump to 8.8

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,7 @@
 {
   "upstream": "elastic/ems-landing-page",
   "branches": [
+    { "name": "v8.8", "checked":  true },
     { "name": "v8.7", "checked":  true },
     { "name": "v8.6", "checked":  true },
     { "name": "v8.5", "checked":  false },

--- a/.ci/jobs/elastic+ems-landing-page+v8.8.yml
+++ b/.ci/jobs/elastic+ems-landing-page+v8.8.yml
@@ -1,12 +1,12 @@
 ---
 - job:
-    name: elastic+ems-landing-page+v8.5+stage
-    display-name: 'elastic / ems-landing-page # v8.5 - stage'
-    description: Build and deploy v8.5 branch to staging server using ./deployStaging.sh.
+    name: elastic+ems-landing-page+v8.8+stage
+    display-name: 'elastic / ems-landing-page # v8.8 - stage'
+    description: Build and deploy v8.8 branch to staging server using ./deployStaging.sh.
     parameters:
     - string:
         name: branch_specifier
-        default: refs/heads/v8.5
+        default: refs/heads/v8.8
         description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
           &lt;commitId&gt;, etc.)
     builders:

--- a/build.sh
+++ b/build.sh
@@ -22,4 +22,4 @@ docker run \
     --volume $PWD:/app \
     --workdir /app \
     $NODE_IMG \
-    bash -c 'npm config set spin false && /opt/yarn*/bin/yarn && yarn run build'
+    bash -c '/opt/yarn*/bin/yarn && yarn run build'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ems_landing_page",
-  "version": "8.7.0",
+  "version": "8.8.0",
   "description": "",
   "main": "main.js",
   "devDependencies": {


### PR DESCRIPTION
* Bumps `package.json` to 8.8.0
* Adds the `v8.8` branch to the backport config (the branch will be created after this PR is merged)
* Removes CI jobs for 8.5 and creates the job for 8.8
* Removes `npm` config from build 


