### PR TITLE
Update pipeline.yml

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent:latest"
   cpu: "2"
-  memory: "1G"
+  memory: "4G"
 
 steps:
   - label: ":hammer_and_wrench: Build"


### PR DESCRIPTION
After reproducing the out of memory error locally, 4G seems to be a good setting. Running this from the project folder allows to limit memory, throwing `error code 137` with 1 or 2 gigabytes while running ok with 4.

```bash
$ docker run --rm \
  -v ${PWD}:/app -w /app \
  --memory=4g \
  --memory-swap=4g \
  --cpus=1 node:18 \
  bash -c "yarn install && yarn build-unsafe"
```