### PR TITLE
[v8.6] fix: upgrade @elastic/eui from 74.0.1 to 74.1.0 (#526)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
     "@elastic/ems-client": "8.4.0",
-    "@elastic/eui": "^74.0.1",
+    "@elastic/eui": "^74.1.0",
     "@emotion/css": "^11.10.5",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1106,10 +1106,10 @@
     semver "^7.3.8"
     topojson-client "^3.1.0"
 
-"@elastic/eui@^74.0.1":
-  version "74.0.1"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-74.0.1.tgz#4397d9d5308f9da7abcf66a376bf87fd6f33af7f"
-  integrity sha512-vaaysWN/CzzMXvt8bGnwHXLPbMgeN7qNUo+mYdqda7aHo2BPvlapmtZmf3L3cIX1m9bxQW/dcuSLLQ5Wcx3fTA==
+"@elastic/eui@^74.1.0":
+  version "74.1.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-74.1.0.tgz#bf60ad199715da3622deb33efb587893a9321073"
+  integrity sha512-pSoIO7h/T4gR3yZbKcadSt8/pPNb45L6s8mR5nHLDo+otAam6Yo3V1u9Upwc5QOVW82hROPfvao44lY7egIiAw==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.6`:
 - [fix: upgrade @elastic/eui from 74.0.1 to 74.1.0 (#526)](https://github.com/elastic/ems-landing-page/pull/526)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)