### PR TITLE
[v8.8] Add yaml resolution for 2.2.2 (#558)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
     "url-parse": "1.5.10",
     "whatwg-fetch": "^3.0.0"
   },
+  "resolutions": {
+    "**/yaml": "^2.2.2"
+  },
   "scripts": {
     "dev": "webpack-dev-server --config webpack.dev.js",
     "lint": "eslint ./public/js --fix",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8026,10 +8026,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^1.10.0, yaml@^1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+yaml@^1.10.0, yaml@^1.10.2, yaml@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
+  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
 
 yargs-parser@^20.2.2, yargs-parser@^20.2.7:
   version "20.2.9"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.8`:
 - [Add yaml resolution for 2.2.2 (#558)](https://github.com/elastic/ems-landing-page/pull/558)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)