### PR TITLE
[v7.17] Add yaml resolution for 2.2.2 (#558)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "**/minimist": "^1.2.6",
     "handlebars-loader/loader-utils":"^1.0.0",
     "**/loader-utils":"^2.0.3",
-    "**/refractor/prismjs": "~1.27.0"
+    "**/refractor/prismjs": "~1.27.0",
+    "**/yaml": "^2.2.2"
   },
   "scripts": {
     "dev": "webpack-dev-server --config webpack.dev.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10925,6 +10925,11 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
+  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
+
 yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [Add yaml resolution for 2.2.2 (#558)](https://github.com/elastic/ems-landing-page/pull/558)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)