### PR TITLE
Upgrade to the new node18 agent, with a tagged version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node18:01"
+  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node18:0.1"
   cpu: "2"
   memory: "4G"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent:latest"
+  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node18:01"
   cpu: "2"
   memory: "4G"
 


### PR DESCRIPTION
This PR changes the agent for the buildkite CI system. This PR needs to be backported and adjusted for the `v7.17` branch to use the `-node16` docker image.

We may be able to use [dynamic pipelines](https://buildkite.com/blog/how-to-build-ci-cd-pipelines-dynamically) to set up an initial step that dynamically generates the `build` step pointing to the appropriate agent image but I don't think it is necessary at this point.
