### PR TITLE
[v8.9] Upgrade to the new node18 agent, with a tagged version (#565)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent:latest"
+  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node18:0.1"
   cpu: "2"
   memory: "4G"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.9`:
 - [Upgrade to the new node18 agent, with a tagged version (#565)](https://github.com/elastic/ems-landing-page/pull/565)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)