### PR TITLE
[v8.9] Buildkite deploy (#552)

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+set -e
+
+# Silently quit if this environment variable is not set
+if [[ -z ${EMS_ENVIRONMENT} ]]; then
+    exit 0
+fi
+unset EMS_ENVIRONMENT
+
+
+function retry {
+    local retries=$1
+    shift
+
+    local count=0
+    until "$@"; do
+        exit=$?
+        wait=$((2 ** count))
+        count=$((count + 1))
+        if [ $count -lt "$retries" ]; then
+            >&2 echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+            sleep $wait
+        else
+            >&2 echo "Retry $count/$retries exited $exit, no more retries left."
+            return $exit
+        fi
+    done
+    return 0
+}
+
+# This script logs into Google Cloud with the service account credentials
+# retrieved from vault and sets up the location of the different
+# GCP buckets used as staging and production environments for
+# EMS Landing Page.
+#
+# Parameters that set up the production environment:
+# - GCS_VAULT_SECRET_PATH: vault location for the GCP service account
+# - PREFIX: the string to prepend for GCP bucket names
+# - ROOT_BRANCH: the branch to set up in the root of maps.elastic.co
+#
+# Parameters to export:
+# - STAGING_BUCKET: GCP bucket storing the staging copy for testing
+# - PRODUCTION_BUCKET: GCP bucket exposed at maps.elastic.co
+# - ARCHIVE_BUCKET: GCP bucket with the archives of previous builds
+# - ROOT_BRANCH
+
+GCS_VAULT_SECRET_PATH="secret/ci/elastic-ems-landing-page/gce/elastic-bekitzur/service-account/maps-landing"
+PREFIX="elastic-bekitzur-maps-landing-page"
+ROOT_BRANCH='v8.7'
+
+echo "--- :gcloud: Authenticate in GCP"
+
+# Login to the Google Cloud with the service account
+GCE_ACCOUNT_SECRET=$(retry 5 vault read --field=value ${GCS_VAULT_SECRET_PATH})
+
+if [[ -z "${GCE_ACCOUNT_SECRET}" ]]; then
+    echo "--- :fire: GCP credentials not set. Expected google service account JSON blob."  1>&2
+    exit 1
+fi
+
+gcloud auth activate-service-account --quiet --key-file <(echo "$GCE_ACCOUNT_SECRET")
+
+echo '--- :bash: Setting up the environment to deploy assets into staging/prod buckets'
+
+export STAGING_BUCKET="${PREFIX}-staging"
+export PRODUCTION_BUCKET="${PREFIX}-live"
+export ARCHIVE_BUCKET="${PREFIX}-archive"
+export ROOT_BRANCH
+
+# Cleanup
+unset GCS_VAULT_SECRET_PATH PREFIX GCE_ACCOUNT_SECRET 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,33 @@ agents:
   memory: "4G"
 
 steps:
-  - label: ":hammer_and_wrench: Build"
-    commands: 
-      - "yarn install"
-      - "yarn build"
+  - key: build
+    label: ":hammer_and_wrench: Build"
+    command: ".buildkite/scripts/build.sh"
+    artifact_paths: release.tar.gz
+    agents:
+      cpu: "2"
+      memory: "4G"
+
+  - key: deploy-staging
+    label: ":rocket: Stage"
+    if: build.tag == null && build.branch =~ /master|v[7-9]\.[0-9]{1,2}/
+    depends_on: build
+    command: ".buildkite/scripts/upload.sh"
+    env:
+      EMS_ENVIRONMENT: "staging"
+
+  - key: should-deploy
+    block: ":one-does-not-simply: Deploy"
+    if: build.tag != null && build.branch =~ /v[7-9]\.[0-9]{1,2}/
+    depends_on: build
+
+  - key: deploy-production
+    label: ":shipit: Deploy"
+    if: build.tag != null && build.branch =~ /v[7-9]\.[0-9]{1,2}/
+    depends_on: should-deploy
+    commands:
+      - ".buildkite/scripts/archive.sh"
+      - ".buildkite/scripts/upload.sh"
+    env:
+      EMS_ENVIRONMENT: "production"

--- a/.buildkite/scripts/archive.sh
+++ b/.buildkite/scripts/archive.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+set -e
+set +x
+
+# This script stores a full copy of the EMS Landing Page
+# production bucket into a zip file and uploads it to
+# an archive bucket
+#
+# Parameters:
+# - STAGING_BUCKET
+# - ARCHIVE_BUCKET
+
+
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+SNAPSHOT_DIR=$PWD/${TIMESTAMP}_snapshot
+ZIP_FILE=${TIMESTAMP}_ems_landingpages.tar.gz
+ZIP_FILE_PATH=$PWD/$ZIP_FILE
+
+
+echo "--- :arrow_down: Downloading gs://$STAGING_BUCKET to snapshot"
+
+if [[ -d "$SNAPSHOT_DIR" ]]; then
+    echo ":fire: $SNAPSHOT_DIR already exist" 1>&2
+    exit 1
+fi
+mkdir -p "$SNAPSHOT_DIR"
+gsutil -m cp -r "gs://$STAGING_BUCKET/*" "$SNAPSHOT_DIR"
+
+echo "--- :compression: Archiving assets into $ZIP_FILE"
+tar -czvf "$ZIP_FILE_PATH" -C "$SNAPSHOT_DIR" .
+
+set +e
+if gsutil -q stat "gs://$ARCHIVE_BUCKET/$ZIP_FILE" ; then
+    echo "--- :fire: ERROR: snapshot file \"gs://$ARCHIVE_BUCKET/$ZIP_FILE\" already exists" 1>&2
+    exit 1
+fi
+set -e
+
+echo "--- :file_cabinet: Uploading snapshot to gs://$ARCHIVE_BUCKET"
+gsutil cp "$ZIP_FILE_PATH" "gs://$ARCHIVE_BUCKET"
+
+
+set +e
+if ! gsutil -q stat "gs://$ARCHIVE_BUCKET/$ZIP_FILE" ; then
+    echo ":fire: ERROR: snapshot file \"gs://$ARCHIVE_BUCKET/$ZIP_FILE\" did not upload successfully" 1>&2
+    exit 1
+fi
+set -e

--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -1,0 +1,16 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+set -eu
+
+echo "--- :yarn:  Installing dependencies"
+yarn install
+
+echo "--- :gear: Building"
+yarn build
+
+echo "--- :compression:  Generate artifact"
+tar -cvzf release.tar.gz build/release

--- a/.buildkite/scripts/upload.sh
+++ b/.buildkite/scripts/upload.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+set -e
+set +x
+
+# Script to upload the result of a build into a GCP bucket, also synchronizing
+# the release with the root of the bucket if the branch of the build is the same
+# as the root branch set up in the pre-command script.
+#
+# Parameters:
+# - BUILDKITE_BRANCH: the branch from which this build was triggered
+# - EMS_ENVIRONMENT: defines if this is going to be a staging or production release
+# - STAGING_BUCKET
+# - PRODUCTION_BUCKET
+# - ROOT_BRANCH
+
+echo "--- :compression: Downloading and uncompressing the build"
+buildkite-agent artifact download release.tar.gz .
+tar -xvzf release.tar.gz
+
+if [[ ! -d ./build/release ]]; then
+    echo "--- :fire:  There is no release to upload" 1>&2
+    exit 1
+fi
+
+SOURCE_PATH="./build/release/"
+
+# Define the destination of the release
+case ${EMS_ENVIRONMENT} in
+    "staging")
+        DEST_BUCKET="gs://${STAGING_BUCKET}"
+    ;;
+    "production")
+        DEST_BUCKET="gs://${PRODUCTION_BUCKET}"
+    ;;
+    "*")
+        echo "--- :fire: ${EMS_ENVIRONMENT}  is not a valid environment definition" 1>&2
+        exit 1
+esac
+
+BRANCH="${BUILDKITE_BRANCH#*:}"
+DEST_PATH="${DEST_BUCKET}/${BRANCH}/"
+
+
+# The trailing slash is critical with the branch.
+# Otherwise, files from subdirs will go to the same destination dir.
+echo "--- :gcloud: Sync ${SOURCE_PATH} to ${DEST_PATH}"
+gsutil -m rsync -d -r -a public-read -j js,css,html "${SOURCE_PATH}" "${DEST_PATH}" 
+
+# If the branch name matches ROOT_BRANCH, it also gets synced to the root
+# excluding paths matching other versions to avoid removing them (v2, v7.x, etc.)
+if [[ "$BRANCH" == "$ROOT_BRANCH" ]]; then
+    echo "--- :gcloud: Sync ${SOURCE_PATH} to ${DEST_BUCKET}"
+    gsutil -m rsync -d -r -a public-read -j js,css,html  -x '^v[\d.]+\/.*$' "${SOURCE_PATH}" "${DEST_BUCKET}/"
+fi

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -27,6 +27,9 @@ spec:
   type: website
   owner: group:ems
   lifecycle: production
+  dependsOn:
+    - "component:ems-file-service"
+    - "component:ems-client"
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
@@ -60,4 +63,5 @@ spec:
           access_level: READ_ONLY
       provider_settings:
         publish_commit_status: true
+        build_tags: true
 

--- a/deployProduction.sh
+++ b/deployProduction.sh
@@ -9,6 +9,12 @@
 set -e
 set +x
 
+# TODO remove the entire script when migration to Buildkite is finished
+# as for now we just skip the rest of the script
+echo "Skipping the script, we are moving to Buildkite"
+exit 0
+
+
 #     *** This job will ***
 #  * download and compress the entire staging bucket into a single snapshot file (all site versions together)
 #  * upload snapshot file to the archive bucket

--- a/deployStaging.sh
+++ b/deployStaging.sh
@@ -9,6 +9,12 @@
 set -e
 set +x
 
+# TODO remove the entire script when migration to Buildkite is finished
+# as for now we just skip the rest of the script
+echo "Skipping the script, we are moving to Buildkite"
+exit 0
+
+
 # Two stage script: first it compiles using node docker container,
 # then it runs itself from within another docker container to deploys to GCP
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.9`:
 - [Buildkite deploy (#552)](https://github.com/elastic/ems-landing-page/pull/552)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)