### PR TITLE
[v7.17] Reduces verbosity of archive download and compression commands (#582)

### DIFF
--- a/.buildkite/scripts/archive.sh
+++ b/.buildkite/scripts/archive.sh
@@ -29,10 +29,14 @@ if [[ -d "$SNAPSHOT_DIR" ]]; then
     exit 1
 fi
 mkdir -p "$SNAPSHOT_DIR"
-gsutil -m cp -r "gs://$STAGING_BUCKET/*" "$SNAPSHOT_DIR"
+set -x
+gsutil -m -q cp -r "gs://$STAGING_BUCKET/*" "$SNAPSHOT_DIR"
+set +x
 
 echo "--- :compression: Archiving assets into $ZIP_FILE"
-tar -czvf "$ZIP_FILE_PATH" -C "$SNAPSHOT_DIR" .
+set -x
+tar -czf "$ZIP_FILE_PATH" -C "$SNAPSHOT_DIR" .
+set +x
 
 set +e
 if gsutil -q stat "gs://$ARCHIVE_BUCKET/$ZIP_FILE" ; then


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [Reduces verbosity of archive download and compression commands (#582)](https://github.com/elastic/ems-landing-page/pull/582)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)