### PR TITLE
[v8.9] [ci] Fix environment for deploy execution (#580) | Reduces verbosity of archive download and compression commands (#582)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ steps:
 
   - key: deploy-staging
     label: ":rocket: Stage"
-    if: build.tag == null && build.branch =~ /^master|v[7-9]\.[0-9]{1,2}$$/
+    if: build.tag == null && build.branch =~ /(^v\d{1,2}\.\d{1,2}(\.\d{1,2})?$$)|(^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12]\d|3[01])$$)/
     depends_on: build
     command: ".buildkite/scripts/upload.sh"
     env:
@@ -22,12 +22,12 @@ steps:
 
   - key: should-deploy
     block: ":one-does-not-simply: Deploy"
-    if: build.tag != null && build.branch =~ /^v[7-9]\.[0-9]{1,2}$$/
+    if: build.tag != null && build.branch =~ /(^master$$)|(^v\d{1,2}\.\d{1,2}(\.\d{1,2})?$$)|(^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12]\d|3[01])$$)/
     depends_on: build
 
   - key: deploy-production
     label: ":shipit: Deploy"
-    if: build.tag != null && build.branch =~ /^v[7-9]\.[0-9]{1,2}$$/
+    if: build.tag != null && build.branch =~ /(^master$$)|(^v\d{1,2}\.\d{1,2}(\.\d{1,2})?$$)|(^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12]\d|3[01])$$)/
     depends_on: should-deploy
     commands:
       - ".buildkite/scripts/archive.sh"

--- a/.buildkite/scripts/archive.sh
+++ b/.buildkite/scripts/archive.sh
@@ -29,10 +29,14 @@ if [[ -d "$SNAPSHOT_DIR" ]]; then
     exit 1
 fi
 mkdir -p "$SNAPSHOT_DIR"
-gsutil -m cp -r "gs://$STAGING_BUCKET/*" "$SNAPSHOT_DIR"
+set -x
+gsutil -m -q cp -r "gs://$STAGING_BUCKET/*" "$SNAPSHOT_DIR"
+set +x
 
 echo "--- :compression: Archiving assets into $ZIP_FILE"
-tar -czvf "$ZIP_FILE_PATH" -C "$SNAPSHOT_DIR" .
+set -x
+tar -czf "$ZIP_FILE_PATH" -C "$SNAPSHOT_DIR" .
+set +x
 
 set +e
 if gsutil -q stat "gs://$ARCHIVE_BUCKET/$ZIP_FILE" ; then

--- a/.buildkite/scripts/upload.sh
+++ b/.buildkite/scripts/upload.sh
@@ -33,16 +33,18 @@ SOURCE_PATH="./build/release/"
 case ${EMS_ENVIRONMENT} in
     "staging")
         DEST_BUCKET="gs://${STAGING_BUCKET}"
+        BRANCH="${BUILDKITE_BRANCH#*:}"
     ;;
     "production")
         DEST_BUCKET="gs://${PRODUCTION_BUCKET}"
+        # When running from a tag, we need to extract the branch from git log :(
+        BRANCH=$(git show -s --pretty=%d HEAD | sed -e 's/^.*origin\/\(.*\))$/\1/g')
     ;;
     "*")
         echo "--- :fire: ${EMS_ENVIRONMENT}  is not a valid environment definition" 1>&2
         exit 1
 esac
 
-BRANCH="${BUILDKITE_BRANCH#*:}"
 DEST_PATH="${DEST_BUCKET}/${BRANCH}/"
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.9`:
 - [[ci] Fix environment for deploy execution (#580)](https://github.com/elastic/ems-landing-page/pull/580)
 - [Reduces verbosity of archive download and compression commands (#582)](https://github.com/elastic/ems-landing-page/pull/582)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)