### PR TITLE
[v8.9] Remove default for backporting to 8.7 (#598)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,7 +3,7 @@
   "branches": [
     { "name": "v8.9", "checked":  true },
     { "name": "v8.8", "checked":  true },
-    { "name": "v8.7", "checked":  true },
+    { "name": "v8.7", "checked":  false },
     { "name": "v7.17", "checked":  true }
   ],
   "labels": ["backport"],


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.9`:
 - [Remove default for backporting to 8.7 (#598)](https://github.com/elastic/ems-landing-page/pull/598)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)