### PR TITLE
[Docs][ci] Update the documentation about buildkite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,32 +1,34 @@
 # Contributing to Elastic Maps Service Landing Page
 
 ## New features and bug fixes
+
 All pull requests must be targeted to the `master` branch.
 
 If multiple releases are affected:
 
 1. Open a PR against the `master` branch.
 1. After the PR is merged, [Backport](#Backporting) the commit(s) to the affected branches.
-1. After all PRs to release branches have been merged and their [respective Jenkins jobs](https://kibana-ci.elastic.co) (ex. elastic / ems-landing-page # v7.2 - stage) have completed successfully review the staged changes at https://maps-staging.elastic.co/{some-release-branch} (ex. [7.2](https://maps-staging.elastic.co/v7.2)).
-1. If the staged changes are ok, deploy the changes to production by logging into [this Jenkins job](https://kibana-ci.elastic.co/job/elastic+ems-landing-page+deploy/) and choose "Build with Parameters".
+1. After all PRs to release branches have been merged and their corresponding Buildkite pipeline executions have completed successfully review the staged changes at https://maps-staging.elastic.co/{some-release-branch} (ex. [7.2](https://maps-staging.elastic.co/v7.2)).
+1. If the staged changes are OK, deploy the changes to production by pushing tags to the affected release branches and accept the deployment block steps at the corresponding buildkite pipeline executions.
 
 ## New Releases
+
 New releases of EMS Landing Page match minor releases of the Elastic Stack.
 
 To add a new release:
 1. Open a PR with the following changes:
-    1. Create a new config in the [.ci/jobs](https://github.com/elastic/ems-landing-page/tree/master/.ci/jobs) directory for a new release branch.
     1. Change the `EMS_VERSION` in config.json.
-    1. Upgrade the `@elastic/ems-client` dependency.
-    1. Bump the verison in `package.json`.
-    1. Add the new version to `.backportrc.json`.
+    1. Upgrade the `@elastic/ems-client` dependency, if necessary.
+    1. Bump the version in `package.json`.
+    1. Update `.backportrc.json` adding the new release and removing any inactive branch.
 1. After the PR is merged, create the new release branch from the `master` branch.
 
 After release:
-1. Open a PR to change the [default `root_branch`](https://github.com/elastic/ems-landing-page/blob/master/.ci/jobs/defaults.yml#L22) to the current release branch (ex. v7.4).
-1. After merging the PR, [backport](#Backporting) the commit to the respective release branch and merge.
-1. Wait for the elastic+ems-landing-page+jjbb Jenkins job to update.
-1. Then log into [this Jenkins job](https://kibana-ci.elastic.co/job/elastic+ems-landing-page+deploy/) and choose "Build with Parameters". This will update https://maps.elastic.co to the current release.
+
+1. Open a PR to change the [default `root_branch`](https://github.com/elastic/ems-landing-page/blob/c57d15ab7550a8b7e3be639e32743cce95c6994b/.buildkite/hooks/pre-command#L54) to the current release branch (ex. v7.4).
+1. After merging the PR, [backport](#Backporting) the commit to all active branches.
+1. Create a new tag on the release branch to trigger a production deployment.
+1. Add the new release branch to the Snyk project.
 
 ## Backporting
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Fix the errors, and redeploy.
 
 ## Continuous Integration and Deployment
 
-This project is built and deployed at Elastic infrastructure with [buildkite](https://buildkite.com/). All definitions and scripts are stored at the `.buildkite` folder.
+This project is built and deployed at Elastic infrastructure with [Buildkite](https://buildkite.com/). All definitions and scripts are stored at the `.buildkite` folder. 
+
+>:warning: Buildkite pipeline executions are only accessible to Elastic team members.
 
 * Any new PR will trigger a build that executes `yarn install && yarn build` as defined in `.buildkite/scripts/build.sh`. Any new commit on the PR will trigger a build and the result will be updated in a comment in the pull request.
 
@@ -76,4 +78,3 @@ This project is built and deployed at Elastic infrastructure with [buildkite](ht
   * A member of the team needs visit the Buildkite pipeline execution website and accept a manual block step to unlock the rest of the pipeline.
   * `archive.sh` will generate a copy of the current production environment and store it in an archive bucket.
   * `upload.sh` will upload the contents to the production environment. If the tag was made on `ROOT_BRANCH` it will also upload the assets to the root folder of the production bucket.
-

--- a/README.md
+++ b/README.md
@@ -9,29 +9,38 @@ that is available within EMS.
 The page is designed as a single-page application. It loads the root manifest from EMS using a cross-domain call. This
 is similar to how Kibana retrieves the manifest from EMS.
 
-Please carefully review the CONTRIBUTING.md document before submitting any pull requests.
+Please carefully review the `CONTRIBUTING.md` document before submitting any pull requests.
 
 ### Prerequisites
 
 `yarn` is used as the dependency manager and script runner for this project. Ensure both `node` and `yarn` are installed on your system.
 
-`webpack` is used for Javascript transpilation.
+`webpack` is used for JavaScript transpilation.
 
-To use the recommended node version for running the dev and compile tasks, you can use
+To use the recommended node version for running the development and compile tasks, you can use [`nvm`](https://github.com/nvm-sh/nvm) with:
 
-> nvm use
+```bash
+nvm use
+```
+
 
 ### Running the page locally
 
 #### Install dependencies
 
-> yarn install
+
+```bash
+yarn install
+```
 
 #### Start the babel compilation and watch task
 
-> yarn dev
 
-Keep this running. The javascript/css will be automatically recompiled when files change.
+```bash
+yarn dev
+```
+
+Keep this running. The JavaScript/CSS will be automatically recompiled when files change.
 
 #### Open the page
 
@@ -43,13 +52,28 @@ You can run the page either from the file-system or any web-server.
 
 To package the app, run the build script.
 
-> yarn build
+
+```bash
+yarn build
+```
 
 This script will put the relevant resources of the app in the `./build/release/**` folder.
 
-If any intermediate tasks break before packaging, such as a javascript linting or compilation failure, the build-script will error out.
+If any intermediate tasks break before packaging, such as a JavaScript linting or compilation failure, the build-script will error out.
 Fix the errors, and redeploy.
 
 ## Continuous Integration and Deployment
-* When a PR is merged Jenkins will run `deployStaging.sh` script, which will place code into the staging bucket.
-* Deploying to production requires manually triggering [this Jenkins job](https://kibana-ci.elastic.co/job/elastic+ems-landing-page+deploy/) to run the [deployProduction.sh](deployProduction.sh) script. This will rsync files in all branches to the production bucket. To trigger, log in and click the "Build with Parameters" link.
+
+This project is built and deployed at Elastic infrastructure with [buildkite](https://buildkite.com/). All definitions and scripts are stored at the `.buildkite` folder.
+
+* Any new PR will trigger a build that executes `yarn install && yarn build` as defined in `.buildkite/scripts/build.sh`. Any new commit on the PR will trigger a build and the result will be updated in a comment in the pull request.
+
+* When a PR is merged to `master` or a version branch (like `v7.17.` or `v8.8`) the pipeline will run the `build.sh` to generate the website. Then `upload.sh` will be executed to push the contents to a staging Google Cloud bucket. If the branch name coincides with the `ROOT_BRANCH` parameter at the `.buildkite/hooks/pre-command` script, it will also upload the contents to the root folder of the staging bucket.
+
+* Deploying to production works as follows:
+  
+  * Push a tag from any of the version branches (like `v7.17` or `v8.8`) to start the pipeline execution with the `build.sh` script.
+  * A member of the team needs visit the Buildkite pipeline execution website and accept a manual block step to unlock the rest of the pipeline.
+  * `archive.sh` will generate a copy of the current production environment and store it in an archive bucket.
+  * `upload.sh` will upload the contents to the production environment. If the tag was made on `ROOT_BRANCH` it will also upload the assets to the root folder of the production bucket.
+


### PR DESCRIPTION
This finishes the migration to Buildkite with some documentation on how the build and deployment to staging and production works.

