### PR TITLE
Fix EMS version in config.json

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -2,7 +2,7 @@
   "default": "production",
   "serviceName": "Elastic Maps Service",
   "SUPPORTED_EMS": {
-    "emsVersion": "v8.7",
+    "emsVersion": "v8.8",
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",


### PR DESCRIPTION
I failed to update the version on this setting 😭

This forces a new deploy of `8.8` to ensure clients are consuming the correct version of the services.

