### PR TITLE
[v8.9] Fix EMS version in config.json (#609)

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -2,7 +2,7 @@
   "default": "production",
   "serviceName": "Elastic Maps Service",
   "SUPPORTED_EMS": {
-    "emsVersion": "v8.7",
+    "emsVersion": "v8.9",
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.9`:
 - [Fix EMS version in config.json (#609)](https://github.com/elastic/ems-landing-page/pull/609)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)