### PR TITLE
[v8.8] Make 8.8 the default branch (#616)

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -51,7 +51,7 @@ function retry {
 
 GCS_VAULT_SECRET_PATH="secret/ci/elastic-ems-landing-page/gce/elastic-bekitzur/service-account/maps-landing"
 PREFIX="elastic-bekitzur-maps-landing-page"
-ROOT_BRANCH='v8.7'
+ROOT_BRANCH='v8.8'
 
 echo "--- :gcloud: Authenticate in GCP"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.8`:
 - [Make 8.8 the default branch (#616)](https://github.com/elastic/ems-landing-page/pull/616)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)