### PR TITLE
[v8.10] Update Buildkite to create releases from master to the root folder (#636)

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -51,7 +51,7 @@ function retry {
 
 GCS_VAULT_SECRET_PATH="secret/ci/elastic-ems-landing-page/gce/elastic-bekitzur/service-account/maps-landing"
 PREFIX="elastic-bekitzur-maps-landing-page"
-ROOT_BRANCH='v8.8'
+ROOT_BRANCH='master'
 
 echo "--- :gcloud: Authenticate in GCP"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ steps:
 
   - key: deploy-staging
     label: ":rocket: Stage"
-    if: build.tag == null && build.branch =~ /(^v\d{1,2}\.\d{1,2}(\.\d{1,2})?$$)|(^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12]\d|3[01])$$)/
+    if: build.tag == null && build.branch =~ /(^master$$)|(^v\d{1,2}\.\d{1,2}(\.\d{1,2})$$)/
     depends_on: build
     command: ".buildkite/scripts/upload.sh"
     env:
@@ -22,12 +22,12 @@ steps:
 
   - key: should-deploy
     block: ":one-does-not-simply: Deploy"
-    if: build.tag != null && build.branch =~ /(^master$$)|(^v\d{1,2}\.\d{1,2}(\.\d{1,2})?$$)|(^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12]\d|3[01])$$)/
+    if: build.tag != null && build.branch =~ /(^master$$)|(^v\d{1,2}\.\d{1,2}(\.\d{1,2})$$)/
     depends_on: build
 
   - key: deploy-production
     label: ":shipit: Deploy"
-    if: build.tag != null && build.branch =~ /(^master$$)|(^v\d{1,2}\.\d{1,2}(\.\d{1,2})?$$)|(^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12]\d|3[01])$$)/
+    if: build.tag != null && build.branch =~ /(^master$$)|(^v\d{1,2}\.\d{1,2}(\.\d{1,2})$$)/
     depends_on: should-deploy
     commands:
       - ".buildkite/scripts/archive.sh"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ If multiple releases are affected:
 1. Open a PR against the `master` branch.
 1. After the PR is merged, [Backport](#Backporting) the commit(s) to the affected branches.
 1. After all PRs to release branches have been merged and their corresponding Buildkite pipeline executions have completed successfully review the staged changes at https://maps-staging.elastic.co/{some-release-branch} (ex. [7.2](https://maps-staging.elastic.co/v7.2)).
-1. If the staged changes are OK, deploy the changes to production by pushing tags to the affected release branches and accept the deployment block steps at the corresponding buildkite pipeline executions.
+1. If the staged changes are OK, deploy the changes to production by pushing tags to `master` and the affected release branches and accept the deployment block steps at the corresponding buildkite pipeline executions.
 
 ## New Releases
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.10`:
 - [Update Buildkite to create releases from master to the root folder (#636)](https://github.com/elastic/ems-landing-page/pull/636)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)