### PR TITLE
[v8.9] Fix buildkite pipeline (#641)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ steps:
 
   - key: deploy-staging
     label: ":rocket: Stage"
-    if: build.tag == null && build.branch =~ /(^master$$)|(^v\d{1,2}\.\d{1,2}(\.\d{1,2})$$)/
+    if: build.tag == null && ( build.branch == "master"  || build.branch =~ /^v\d{1,2}\.\d{1,2}$$/ )
     depends_on: build
     command: ".buildkite/scripts/upload.sh"
     env:
@@ -22,12 +22,12 @@ steps:
 
   - key: should-deploy
     block: ":one-does-not-simply: Deploy"
-    if: build.tag != null && build.branch =~ /(^master$$)|(^v\d{1,2}\.\d{1,2}(\.\d{1,2})$$)/
+    if: build.tag != null && ( build.branch == "master"  || build.branch =~ /^v\d{1,2}\.\d{1,2}$$/ )
     depends_on: build
 
   - key: deploy-production
     label: ":shipit: Deploy"
-    if: build.tag != null && build.branch =~ /(^master$$)|(^v\d{1,2}\.\d{1,2}(\.\d{1,2})$$)/
+    if: build.tag != null && ( build.branch == "master"  || build.branch =~ /^v\d{1,2}\.\d{1,2}$$/ )
     depends_on: should-deploy
     commands:
       - ".buildkite/scripts/archive.sh"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.9`:
 - [Fix buildkite pipeline (#641)](https://github.com/elastic/ems-landing-page/pull/641)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)