### PR TITLE
[v8.10] Updating the contributing documentation (#655)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,7 @@ If multiple releases are affected:
 
 1. Open a PR against the `master` branch.
 1. After the PR is merged, [Backport](#Backporting) the commit(s) to the affected branches.
-1. After all PRs to release branches have been merged and their corresponding Buildkite pipeline executions have completed successfully review the staged changes at https://maps-staging.elastic.co/{some-release-branch} (ex. [7.2](https://maps-staging.elastic.co/v7.2)).
-1. If the staged changes are OK, deploy the changes to production by pushing tags to `master` and the affected release branches and accept the deployment block steps at the corresponding buildkite pipeline executions.
+1. After all PRs to release branches have been merged and their corresponding Buildkite pipeline executions have completed successfully review the staged changes at `https://maps-staging.elastic.co/{some-release-branch}` (ex. [7.2](https://maps-staging.elastic.co/v7.2)).
 
 ## New Releases
 
@@ -22,13 +21,21 @@ To add a new release:
     1. Bump the version in `package.json`.
     1. Update `.backportrc.json` adding the new release and removing any inactive branch.
 1. After the PR is merged, create the new release branch from the `master` branch.
-
-After release:
-
-1. Open a PR to change the [default `root_branch`](https://github.com/elastic/ems-landing-page/blob/c57d15ab7550a8b7e3be639e32743cce95c6994b/.buildkite/hooks/pre-command#L54) to the current release branch (ex. v7.4).
-1. After merging the PR, [backport](#Backporting) the commit to all active branches.
-1. Create a new tag on the release branch to trigger a production deployment.
+1. Check in staging that the new branch is deployed
 1. Add the new release branch to the Snyk project.
+1. Deploy the branch (next section)
+
+## Deployment to production
+
+Deploy the changes to production by doing the following steps per each affected branch (including `master`):
+
+1. Checkout the release branch (say `v8.9`)
+1. Create a tag with the pattern `branch-date` (`master-2023-07-25`, `v8.9-2023-07-25`)
+1. Push it to the Elastic remote `git push --tags`
+1. A new deploy job will be triggered in Buildkite with a blocking step that needs to be accepted by a member of the team
+1. Wait for the job to finish and review the changes in production at <https://maps.elastic.co>` or `https://maps.elastic.co/{some-release-branch}/` (ex. [7.2](https://maps.elastic.co/v7.2))
+
+**Note**: The Buildkite deploy job does not take any assets from staging. It builds all the assets from the source code and syncs with the production bucket, removing old assets if necessary.
 
 ## Backporting
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.10`:
 - [Updating the contributing documentation (#655)](https://github.com/elastic/ems-landing-page/pull/655)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)