### PR TITLE
[v7.17] Remove 8.8 from backporting (#660)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,7 +2,7 @@
   "upstream": "elastic/ems-landing-page",
   "branches": [
     { "name": "v8.9", "checked":  true },
-    { "name": "v8.8", "checked":  true },
+    { "name": "v8.8", "checked":  false },
     { "name": "v8.7", "checked":  false },
     { "name": "v7.17", "checked":  true }
   ],


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - Remove 8.8 from backporting (#660) (4ac92161)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)