### PR TITLE
[v8.11] Upgrade whatwg-fetch from 3.6.2 to 3.6.16 (#674)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "url-parse": "1.5.10",
-    "whatwg-fetch": "^3.0.0"
+    "whatwg-fetch": "^3.6.16"
   },
   "resolutions": {
     "**/yaml": "^2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8126,10 +8126,10 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
-whatwg-fetch@^3.0.0:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
-  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
+whatwg-fetch@^3.6.16:
+  version "3.6.19"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.19.tgz#caefd92ae630b91c07345537e67f8354db470973"
+  integrity sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.11`:
 - [Upgrade whatwg-fetch from 3.6.2 to 3.6.16 (#674)](https://github.com/elastic/ems-landing-page/pull/674)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)