### PR TITLE
[v8.10] [Buikite] Fix version and branch checks (#694)

### DIFF
--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -17,7 +17,7 @@ else
   yarn build-unsafe
 fi
 
-if [[ "${BUILDKITE_BRANCH}" == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]] ; then
+if [[ "${BUILDKITE_BRANCH}" == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}"* ]] ; then
   echo "--- :elastic-cloud: Replacing version in config.json"
   yarn serverless
 fi

--- a/public/config.json
+++ b/public/config.json
@@ -2,7 +2,7 @@
   "default": "production",
   "serviceName": "Elastic Maps Service",
   "SUPPORTED_EMS": {
-    "emsVersion": "v8.9",
+    "emsVersion": "8.10.0",
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",

--- a/public/main.js
+++ b/public/main.js
@@ -76,7 +76,7 @@ async function getEmsClient(config, deployment, locale) {
   const license = config.license;
   const emsClient = new EMSClient({
     appName: 'ems-landing-page',
-    appVersion: version,
+    appVersion: emsVersion,
     fileApiUrl,
     tileApiUrl,
     emsVersion,


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.10`:
 - [[Buikite] Fix version and branch checks (#694)](https://github.com/elastic/ems-landing-page/pull/694)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)