### PR TITLE
[v8.11] Upgrade to Node 20 (#699)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node18:0.1"
+  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20:0.1"
   cpu: "2"
   memory: "4G"
 

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/iron

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "css-minimizer-webpack-plugin": "^4.2.2",
     "eslint": "^8.32.0",
     "eslint-plugin-react": "^7.32.1",
-    "favicons": "^7.1.2",
+    "favicons": "^7.1.4",
     "favicons-webpack-plugin": "^6.0.0",
     "file-loader": "^6.2.0",
     "handlebars": "^4.7.7",
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
-    "@elastic/ems-client": "8.5.0",
+    "@elastic/ems-client": "8.5.1",
     "@elastic/eui": "^89.1.0",
     "@emotion/css": "^11.10.6",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
@@ -80,6 +80,6 @@
   "author": "Elastic",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {
-    "node": ">=16 <=18"
+    "node": ">=18 <=20"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1333,10 +1333,10 @@
   dependencies:
     tslib "^1.9.3"
 
-"@elastic/ems-client@8.5.0":
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-8.5.0.tgz#5e3988ab01dee54bace9f8c2f9e71470b26a1bfa"
-  integrity sha512-uEI8teyS3gWErlEL4mEYh0MDHms9Rp3eEHKnMMSdMtAkaa3xs60SOm3Vd0ld9sIPsyarQHrAybAw30GXVXXRjw==
+"@elastic/ems-client@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-8.5.1.tgz#60c179e53ad81f5e26680e7e1c6cbffe4fb64aed"
+  integrity sha512-lc65i/cW6fGuRMt3pUte35sL8HxXM7TbYJwx1bHWcWn4aN3zv8i5RhPKFz+Wr/1ubfFOTrIoFYCP4h1uq2O/dQ==
   dependencies:
     "@types/geojson" "^7946.0.10"
     "@types/lru-cache" "^5.1.0"
@@ -4058,7 +4058,7 @@ favicons-webpack-plugin@^6.0.0:
   optionalDependencies:
     html-webpack-plugin "^5.5.0"
 
-favicons@^7.1.2:
+favicons@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/favicons/-/favicons-7.1.4.tgz#bc0ed1a8d752f94a36912294681925e272d25ff0"
   integrity sha512-lnZpVgT7Fzz+DUjioKF1dMwLYlpqWCaB4gIksIfIKwtlhHO1Q7w23hERwHQjEsec+43iENwbTAPRDW3XvpLhbg==


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.11`:
 - [Upgrade to Node 20 (#699)](https://github.com/elastic/ems-landing-page/pull/699)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)