### PR TITLE
[v7.17] Upgrade to Node 20 (#699)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node18:0.1"
+  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20:0.1"
   cpu: "2"
   memory: "4G"
 

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/iron

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "css-minimizer-webpack-plugin": "^4.2.2",
     "eslint": "^8.32.0",
     "eslint-plugin-react": "^7.32.1",
-    "favicons": "^7.1.2",
+    "favicons": "^7.1.4",
     "favicons-webpack-plugin": "^6.0.0",
     "file-loader": "^6.2.0",
     "handlebars": "^4.7.7",
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
-    "@elastic/ems-client": "7.16.0",
+    "@elastic/ems-client": "7.17.1",
     "@elastic/eui": "53.0.2",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.5.0",
@@ -81,6 +81,6 @@
   "author": "Elastic",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {
-    "node": ">=16 <=18"
+    "node": ">=18 <=20"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,18 +1321,18 @@
   dependencies:
     tslib "^1.9.3"
 
-"@elastic/ems-client@7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.16.0.tgz#92db94126bac0b95fbf156fe609f68979e7af4b6"
-  integrity sha512-NgMB5vqj6I7lxVsysrz6eB1EW6gsZj7SWWs79WSiiKQeNuRg82tJhvbHQnWezjIS4UKOtoGxZsg475EHVZB46g==
+"@elastic/ems-client@7.17.1":
+  version "7.17.1"
+  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.17.1.tgz#0f76c6523b75641c858f6537e524cbcbcad64edd"
+  integrity sha512-dPiiXA0ebPGtXt4m732lqR7DSLKG1NGvQCAOxLl8DNTeUKw69aWSFiG3kgPBJnl3Z0+aUnU1dc+mRUqbjzQDqw==
   dependencies:
-    "@types/geojson" "^7946.0.7"
+    "@types/geojson" "^7946.0.10"
     "@types/lru-cache" "^5.1.0"
-    "@types/topojson-client" "^3.0.0"
+    "@types/topojson-client" "^3.1.1"
     "@types/topojson-specification" "^1.0.1"
     lodash "^4.17.15"
     lru-cache "^6.0.0"
-    semver "^7.3.2"
+    semver "7.5.4"
     topojson-client "^3.1.0"
 
 "@elastic/eui@53.0.2":
@@ -1834,7 +1834,7 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/geojson@*", "@types/geojson@^7946.0.7":
+"@types/geojson@*":
   version "7946.0.8"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
   integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
@@ -2128,10 +2128,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/topojson-client@^3.0.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@types/topojson-client/-/topojson-client-3.1.0.tgz#2fd96d5e64f4f512742f22194f3e1e0443c27233"
-  integrity sha512-wmjTmMkF6k6m3Tn4mIyRjw8KUQZLHB1TxNcpGYirvV/aCINkC0eMJsUO/OPMkKIB6VO5iA6Vp39bmAq6QgvSfA==
+"@types/topojson-client@^3.1.1":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@types/topojson-client/-/topojson-client-3.1.4.tgz#81b83f9ecd6542dc5c3df21967f992e3fe192c33"
+  integrity sha512-Ntf3ZSetMYy7z3PrVCvcqmdRoVhgKA9UKN0ZuuZf8Ts2kcyL4qK34IXBs6qO5fem62EK4k03PtkJPVoroVu4/w==
   dependencies:
     "@types/geojson" "*"
     "@types/topojson-specification" "*"
@@ -4080,7 +4080,7 @@ favicons-webpack-plugin@^6.0.0:
   optionalDependencies:
     html-webpack-plugin "^5.5.0"
 
-favicons@^7.1.2:
+favicons@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/favicons/-/favicons-7.1.4.tgz#bc0ed1a8d752f94a36912294681925e272d25ff0"
   integrity sha512-lnZpVgT7Fzz+DUjioKF1dMwLYlpqWCaB4gIksIfIKwtlhHO1Q7w23hERwHQjEsec+43iENwbTAPRDW3XvpLhbg==
@@ -7286,7 +7286,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0, semver@^6.0.0, semver@^6.3.0, semver@^6.3.1, semver@^7.3.2, semver@^7.3.5, semver@^7.5.4:
+"semver@2 || 3 || 4 || 5", semver@7.5.4, semver@^5.5.0, semver@^5.6.0, semver@^6.0.0, semver@^6.3.0, semver@^6.3.1, semver@^7.3.5, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [Upgrade to Node 20 (#699)](https://github.com/elastic/ems-landing-page/pull/699)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)