### PR TITLE
Bump to 8.14

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,10 +1,10 @@
 {
   "upstream": "elastic/ems-landing-page",
   "branches": [
-    { "name": "v8.13", "checked":  true },
-    { "name": "v8.12", "checked":  true },
-    { "name": "v8.11", "checked": true },
-    { "name": "v7.17", "checked":  true }
+    { "name": "v8.14", "checked": true },
+    { "name": "v8.13", "checked": true },
+    { "name": "v8.12", "checked": true },
+    { "name": "v7.17", "checked": true }
   ],
   "labels": ["backport"],
   "multipleCommits": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ems_landing_page",
-  "version": "8.13.0",
+  "version": "8.14.0",
   "description": "",
   "main": "main.js",
   "devDependencies": {

--- a/public/config.json
+++ b/public/config.json
@@ -2,7 +2,7 @@
   "default": "production",
   "serviceName": "Elastic Maps Service",
   "SUPPORTED_EMS": {
-    "emsVersion": "8.13.0",
+    "emsVersion": "8.14.0",
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",


### PR DESCRIPTION
Bumps the master branch to 8.14 following the [New release docs](https://github.com/elastic/ems-landing-page/blob/4ac92161e4bc8e1eb82a0d98ea14ccf047ad21e2/CONTRIBUTING.md#new-releases)

- Updates the package.json to 8.14.0
- Updates the EMS version in the config file to 8.14
- Adds the 8.14 branch to the backport



