### PR TITLE
Change the link in logo depending on the file API URL

### DIFF
--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -326,13 +326,18 @@ export class App extends Component {
       }
     };
 
+    // Set up the link on the logo to go to the root or up if relative
+    const fileApUrl = this.props.client.getFileApiUrl(); 
+    const logoLink = fileApUrl.startsWith('/') ? '../' : '/';
+
+
     return (
       <EuiProvider colorMode="light">
         <EuiHeader>
           <EuiHeaderSectionItem border="right">
             <EuiToolTip delay="long" 
               content={`EMS version: ${this.props.client._emsVersion}`}>
-              <EuiHeaderLogo href="/" aria-label={`${this.props.serviceName} home`} iconType="emsApp" >
+              <EuiHeaderLogo href={logoLink} aria-label={`${this.props.serviceName} home`} iconType="emsApp" >
                 {this.props.serviceName}
               </EuiHeaderLogo>
             </EuiToolTip>


### PR DESCRIPTION
Depending on the EMS File Service API used to instantiate the client, the frontend will render a link

* To the root of the server if running against an external endpoint (current behavior)
* To the parent of the current URL if running aganist an internal endpoint (for local installations of EMS)

