### PR TITLE
[v8.14] Change the link in logo depending on the file API URL (#712)

### DIFF
--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -326,13 +326,18 @@ export class App extends Component {
       }
     };
 
+    // Set up the link on the logo to go to the root or up if relative
+    const fileApUrl = this.props.client.getFileApiUrl(); 
+    const logoLink = fileApUrl.startsWith('/') ? '../' : '/';
+
+
     return (
       <EuiProvider colorMode="light">
         <EuiHeader>
           <EuiHeaderSectionItem border="right">
             <EuiToolTip delay="long" 
               content={`EMS version: ${this.props.client._emsVersion}`}>
-              <EuiHeaderLogo href="/" aria-label={`${this.props.serviceName} home`} iconType="emsApp" >
+              <EuiHeaderLogo href={logoLink} aria-label={`${this.props.serviceName} home`} iconType="emsApp" >
                 {this.props.serviceName}
               </EuiHeaderLogo>
             </EuiToolTip>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.14`:
 - [Change the link in logo depending on the file API URL (#712)](https://github.com/elastic/ems-landing-page/pull/712)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)