### PR TITLE
[v7.17] Bump follow-redirects from 1.15.4 to 1.15.6 (#722)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4228,9 +4228,9 @@ focus-lock@^1.3.2:
     tslib "^2.0.3"
 
 follow-redirects@^1.0.0:
-  version "1.15.4"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
-  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [Bump follow-redirects from 1.15.4 to 1.15.6 (#722)](https://github.com/elastic/ems-landing-page/pull/722)

<!--- Backport version: 9.4.5 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)