### PR TITLE
[v7.17] Remove 8.12 from backport settings (#736)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,10 +1,9 @@
 {
   "upstream": "elastic/ems-landing-page",
   "branches": [
-    { "name": "v8.9", "checked":  true },
-    { "name": "v8.8", "checked":  false },
-    { "name": "v8.7", "checked":  false },
-    { "name": "v7.17", "checked":  true }
+    { "name": "v8.14", "checked": true },
+    { "name": "v8.13", "checked": true },
+    { "name": "v7.17", "checked": true }
   ],
   "labels": ["backport"],
   "multipleCommits": true


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [Remove 8.12 from backport settings (#736)](https://github.com/elastic/ems-landing-page/pull/736)

<!--- Backport version: 9.4.5 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)