### PR TITLE
Use hostname to get the link logo

### DIFF
--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -327,8 +327,9 @@ export class App extends Component {
     };
 
     // Set up the link on the logo to go to the root or up if relative
-    const fileApUrl = this.props.client.getFileApiUrl(); 
-    const logoLink = fileApUrl.startsWith('/') ? '../' : '/';
+    const fileApUrl = this.props.client.getFileApiUrl();
+    const logoLink =
+      new URL(fileApUrl).hostname == window.location.hostname ? '../' : '/';
 
 
     return (

--- a/public/js/components/map.js
+++ b/public/js/components/map.js
@@ -22,7 +22,7 @@ export class Map extends Component {
       const contextIds = ['webgl', 'experimental-webgl'];
       return contextIds.some( (c) => { 
         const ctx = canvas.getContext(c); 
-        return ctx && ctx instanceof WebGLRenderingContext
+        return ctx && ctx instanceof WebGLRenderingContext;
       });
     } catch (error) {
       return false;


### PR DESCRIPTION
In order to get the correct link to put in the page header for self-hosted EMS deployments, compare the location of the current window with the URL passed by EMS Client.
