### PR TITLE
[v8.13] Use hostname to get the link logo (#741)

### DIFF
--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -327,8 +327,9 @@ export class App extends Component {
     };
 
     // Set up the link on the logo to go to the root or up if relative
-    const fileApUrl = this.props.client.getFileApiUrl(); 
-    const logoLink = fileApUrl.startsWith('/') ? '../' : '/';
+    const fileApUrl = this.props.client.getFileApiUrl();
+    const logoLink =
+      new URL(fileApUrl).hostname == window.location.hostname ? '../' : '/';
 
 
     return (

--- a/public/js/components/map.js
+++ b/public/js/components/map.js
@@ -22,7 +22,7 @@ export class Map extends Component {
       const contextIds = ['webgl', 'experimental-webgl'];
       return contextIds.some( (c) => { 
         const ctx = canvas.getContext(c); 
-        return ctx && ctx instanceof WebGLRenderingContext
+        return ctx && ctx instanceof WebGLRenderingContext;
       });
     } catch (error) {
       return false;


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.13`:
 - [Use hostname to get the link logo (#741)](https://github.com/elastic/ems-landing-page/pull/741)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)