### PR TITLE
[v7.17] Use hostname to get the link logo (#741)

### DIFF
--- a/public/js/components/app.js
+++ b/public/js/components/app.js
@@ -220,8 +220,9 @@ export class App extends Component {
     };
 
     // Set up the link on the logo to go to the root or up if relative
-    const fileApUrl = this.props.client.getFileApiUrl(); 
-    const logoLink = fileApUrl.startsWith('/') ? '../' : '/';
+    const fileApUrl = this.props.client.getFileApiUrl();
+    const logoLink =
+      new URL(fileApUrl).hostname == window.location.hostname ? '../' : '/';
 
 
     return (


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [Use hostname to get the link logo (#741)](https://github.com/elastic/ems-landing-page/pull/741)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)