### PR TITLE
[v8.15] refactor: 💡 Use createRoot (React 18) (#746)

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -8,12 +8,14 @@
 import './main.css';
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
+
 import URL from 'url-parse';
 import 'whatwg-fetch';
-import { version } from '../package.json';
-import { App } from './js/components/app';
+
 import { EMSClient } from '@elastic/ems-client/target/node';
+
+import { App } from './js/components/app';
 
 start();
 
@@ -41,10 +43,11 @@ async function start() {
   };
 
   const serviceName = config.serviceName || 'Elastic Maps Service';
+  const container = document.getElementById('wrapper');
+  const root = createRoot(container);
 
-  ReactDOM.render(
+  root.render(
     <App client={emsClient} serviceName={serviceName} layers={emsLayers} />,
-    document.getElementById('wrapper')
   );
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.15`:
 - [refactor: 💡 Use createRoot (React 18) (#746)](https://github.com/elastic/ems-landing-page/pull/746)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)