### PR TITLE
[v8.15] chore(deps): update dependency core-js to v3.38.1 (#776)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-react-intl": "8.2.25",
     "clean-webpack-plugin": "4.0.0",
     "copy-webpack-plugin": "12.0.2",
-    "core-js": "3.36.0",
+    "core-js": "3.38.1",
     "css-loader": "6.10.0",
     "css-minimizer-webpack-plugin": "6.0.0",
     "eslint": "8.56.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3630,10 +3630,10 @@ core-js-compat@^3.37.1, core-js-compat@^3.38.0:
   dependencies:
     browserslist "^4.23.3"
 
-core-js@3.36.0:
-  version "3.36.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.36.0.tgz#e752fa0b0b462a0787d56e9d73f80b0f7c0dde68"
-  integrity sha512-mt7+TUBbTFg5+GngsAxeKBTl5/VS0guFeJacYge9OmHb+m058UwwIm41SE9T4Den7ClatV57B6TYTuJ0CX1MAw==
+core-js@3.38.1:
+  version "3.38.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.38.1.tgz#aa375b79a286a670388a1a363363d53677c0383e"
+  integrity sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==
 
 core-js@^2.6.5:
   version "2.6.12"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.15`:
 - [chore(deps): update dependency core-js to v3.38.1 (#776)](https://github.com/elastic/ems-landing-page/pull/776)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)