### PR TITLE
[v8.15] chore(deps): update dependency husky to v9.1.5 (#780)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "handlebars": "4.7.8",
     "handlebars-loader": "1.7.3",
     "html-webpack-plugin": "5.6.0",
-    "husky": "9.0.11",
+    "husky": "9.1.5",
     "node-fetch": "3.3.2",
     "node-polyfill-webpack-plugin": "4.0.0",
     "process": "0.11.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5352,10 +5352,10 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-husky@9.0.11:
-  version "9.0.11"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-9.0.11.tgz#fc91df4c756050de41b3e478b2158b87c1e79af9"
-  integrity sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==
+husky@9.1.5:
+  version "9.1.5"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.5.tgz#2b6edede53ee1adbbd3a3da490628a23f5243b83"
+  integrity sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==
 
 iconv-lite@0.4.24:
   version "0.4.24"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.15`:
 - [chore(deps): update dependency husky to v9.1.5 (#780)](https://github.com/elastic/ems-landing-page/pull/780)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)