### PR TITLE
[v7.17] chore(deps): update docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20 docker tag to v0.4 (#783)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20:0.1"
+  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20:0.4@sha256:709d4bf1596ca236f0f59fc30ce62a7598b544ed32c11f2869299beded97c471"
   cpu: "2"
   memory: "4G"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [chore(deps): update docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20 docker tag to v0.4 (#783)](https://github.com/elastic/ems-landing-page/pull/783)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)