### PR TITLE
[v7.17] Revert "fix(deps): update dependency @mapbox/mapbox-gl-rtl-text to ^0.3.0 (#787)" (#836)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@elastic/eui": "^93.0.0",
     "@emotion/css": "^11.10.6",
     "@hello-pangea/dnd": "16.6.0",
-    "@mapbox/mapbox-gl-rtl-text": "^0.3.0",
+    "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.5.0",
     "@turf/center": "6.5.0",
     "maplibre-gl": "4.0.2",

--- a/public/js/components/map.js
+++ b/public/js/components/map.js
@@ -6,11 +6,13 @@
  */
 
 import maplibre from 'maplibre-gl';
+import mbRtlPlugin from '@mapbox/mapbox-gl-rtl-text/mapbox-gl-rtl-text.min.js';
 import turfBbox from '@turf/bbox';
 import turfCenter from '@turf/center';
 import React, { Component } from 'react';
 
-maplibre.setRTLTextPlugin('mapbox-gl-rtl-text.js');
+maplibre.setRTLTextPlugin(mbRtlPlugin);
+
 export class Map extends Component {
 
   static isSupported() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1818,10 +1818,10 @@
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
   integrity sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=
 
-"@mapbox/mapbox-gl-rtl-text@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-rtl-text/-/mapbox-gl-rtl-text-0.3.0.tgz#dbf73b11e1dbb0cef2aa869168babab572ae559c"
-  integrity sha512-OwQplFqAAEYRobrTKm2wiVP+wcpUVlgXXiUMNQ8tcm5gPN5SQRXFADmITdQOaec4LhDhuuFchS7TS8ua8dUl4w==
+"@mapbox/mapbox-gl-rtl-text@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-rtl-text/-/mapbox-gl-rtl-text-0.2.3.tgz#a26ecfb3f0061456d93ee8570dd9587d226ea8bd"
+  integrity sha512-RaCYfnxULUUUxNwcUimV9C/o2295ktTyLEUzD/+VWkqXqvaVfFcZ5slytGzb2Sd/Jj4MlbxD0DCZbfa6CzcmMw==
 
 "@mapbox/point-geometry@0.1.0", "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
   version "0.1.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [Revert &quot;fix(deps): update dependency @mapbox/mapbox-gl-rtl-text to ^0.3.0 (#787)&quot; (#836)](https://github.com/elastic/ems-landing-page/pull/836)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)