### PR TITLE
[v7.17] fix(deps): update dependency chroma-js to v2.6.0 (#820)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "6.5.0",
     "@turf/center": "6.5.0",
+    "chroma-js": "2.6.0",
     "maplibre-gl": "4.0.2",
     "moment": "2.30.1",
     "react": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3252,7 +3252,7 @@ chokidar@^3.4.0, chokidar@^3.6.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chroma-js@^2.4.2:
+chroma-js@2.6.0, chroma-js@^2.4.2:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.6.0.tgz#578743dd359698a75067a19fa5571dec54d0b70b"
   integrity sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [fix(deps): update dependency chroma-js to v2.6.0 (#820)](https://github.com/elastic/ems-landing-page/pull/820)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)