### PR TITLE
[v7.17] chore(deps): update dependency style-loader to v4 (#868)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node-polyfill-webpack-plugin": "4.0.0",
     "process": "0.11.10",
     "resolve-url-loader": "5.0.0",
-    "style-loader": "3.3.4",
+    "style-loader": "4.0.0",
     "url": "0.11.4",
     "webpack": "5.94.0",
     "webpack-cli": "5.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8321,10 +8321,10 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-style-loader@3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.4.tgz#f30f786c36db03a45cbd55b6a70d930c479090e7"
-  integrity sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==
+style-loader@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-4.0.0.tgz#0ea96e468f43c69600011e0589cb05c44f3b17a5"
+  integrity sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==
 
 style-to-object@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [chore(deps): update dependency style-loader to v4 (#868)](https://github.com/elastic/ems-landing-page/pull/868)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)