### PR TITLE
[v7.17] Update yaml and semver resolutions (#885)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,9 +65,9 @@
     "whatwg-fetch": "3.6.20"
   },
   "resolutions": {
-    "**/yaml": "^2.3.0",
+    "**/yaml": "^2.5.0",
     "**/semver": "^7.6.3"
-   },
+  },
   "scripts": {
     "dev": "webpack-dev-server --config webpack.dev.js",
     "lint": "eslint ./public/js --fix",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9240,10 +9240,10 @@ yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yaml@^1.10.0, yaml@^2.3.0:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.4.tgz#53fc1d514be80aabf386dc6001eb29bf3b7523b2"
-  integrity sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==
+yaml@^1.10.0, yaml@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.5.0.tgz#c6165a721cf8000e91c36490a41d7be25176cf5d"
+  integrity sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==
 
 yargs-parser@^20.2.2, yargs-parser@^20.2.7:
   version "20.2.9"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [Update yaml and semver resolutions (#885)](https://github.com/elastic/ems-landing-page/pull/885)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)