### PR TITLE
Bumps to 9.0

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,9 +1,9 @@
 {
   "upstream": "elastic/ems-landing-page",
   "branches": [
-    { "name": "v8.16", "checked": true },
-    { "name": "v8.15", "checked": true },
-    { "name": "v7.17", "checked": true }
+    { "name": "v9.0", "checked": true },
+    { "name": "v8.17", "checked": true },
+    { "name": "v8.16", "checked": true }
   ],
   "labels": ["backport"],
   "multipleCommits": false

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -4,7 +4,8 @@
     { "name": "v9.0", "checked": true },
     { "name": "v8.x", "checked": true },
     { "name": "v8.17", "checked": true },
-    { "name": "v8.16", "checked": true }
+    { "name": "v8.16", "checked": true },
+    { "name": "v7.17", "checked": true }
   ],
   "labels": ["backport"],
   "multipleCommits": false

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,6 +2,7 @@
   "upstream": "elastic/ems-landing-page",
   "branches": [
     { "name": "v9.0", "checked": true },
+    { "name": "v8.x", "checked": true },
     { "name": "v8.17", "checked": true },
     { "name": "v8.16", "checked": true }
   ],

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -5,6 +5,7 @@
     { "name": "v8.x", "checked": true },
     { "name": "v8.17", "checked": true },
     { "name": "v8.16", "checked": true },
+    { "name": "v8.15", "checked": true },
     { "name": "v7.17", "checked": true }
   ],
   "labels": ["backport"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ems_landing_page",
-  "version": "8.16.0",
+  "version": "9.0.0",
   "description": "",
   "main": "main.js",
   "devDependencies": {

--- a/public/config.json
+++ b/public/config.json
@@ -2,7 +2,7 @@
   "default": "production",
   "serviceName": "Elastic Maps Service",
   "SUPPORTED_EMS": {
-    "emsVersion": "8.16.0",
+    "emsVersion": "9.0.0",
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",

--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,9 @@
   ],
   "labels": [
     "dependencies",
-    "v8.16",
-    "v8.15",
-    "v7.17"
+    "v9.0",
+    "v8.17",
+    "v8.16"
   ],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,9 @@
     "dependencies",
     "v9.0",
     "v8.17",
-    "v8.16"
+    "v8.16",
+    "v8.15",
+    "v7.17"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Bumps the master branch to 9.0 following the [New release docs](https://github.com/elastic/ems-landing-page/blob/4ac92161e4bc8e1eb82a0d98ea14ccf047ad21e2/CONTRIBUTING.md#new-releases)

- Updates the package.json to 9.0.0
- Updates the EMS version in the config file to 9.0.0
- Adds the 9.0 branch to the backport and removes 7.17
- Updates renovate.json file

Depends on https://github.com/elastic/ems-file-service/pull/341 (merged)

>[!important]
> After this PR is merged a new `v9.0` sibling branch and initial tag will be created to get the `v9.0` route published in our GCP buckets.

>[!important]
> A `v8.x` branch has already been cut and future backports from `master` will go to `v9.0`, `v8.x`, `v8.17`, `v8.16`, `v8.15`, and `v7.17`. This is **a lot**, we may need to start working on automating the merge of backports soon to reduce the manual work.