### PR TITLE
Bumps to 8.17

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,8 +1,8 @@
 {
   "upstream": "elastic/ems-landing-page",
   "branches": [
+    { "name": "v8.17", "checked": true },
     { "name": "v8.16", "checked": true },
-    { "name": "v8.15", "checked": true },
     { "name": "v7.17", "checked": true }
   ],
   "labels": ["backport"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ems_landing_page",
-  "version": "8.16.0",
+  "version": "8.17.0",
   "description": "",
   "main": "main.js",
   "devDependencies": {

--- a/public/config.json
+++ b/public/config.json
@@ -2,7 +2,7 @@
   "default": "production",
   "serviceName": "Elastic Maps Service",
   "SUPPORTED_EMS": {
-    "emsVersion": "8.16.0",
+    "emsVersion": "8.17.0",
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",

--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,8 @@
   ],
   "labels": [
     "dependencies",
+    "v8.17",
     "v8.16",
-    "v8.15",
     "v7.17"
   ],
   "packageRules": [


### PR DESCRIPTION
Bumps the master branch to 8.17 following the [New release docs](https://github.com/elastic/ems-landing-page/blob/4ac92161e4bc8e1eb82a0d98ea14ccf047ad21e2/CONTRIBUTING.md#new-releases)

- Updates the package.json to 8.17.0
- Updates the EMS version in the config file to 8.17
- Adds the 8.17 branch to the backport
- Updates renovate.json

>[!Important]
> In preparation of the new `v9.x` series. This PR is against the `v8.x` branch

>[!Important]
> After this PR is merged a sibling `v8.17` branch synchronized with `v8.x` will be created to deploy a new version in the `v8.17` route in our GCP buckets.

