### PR TITLE
[v7.17] fix(deps): update dependency @elastic/eui to v95.10.1 (#932)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1512,9 +1512,9 @@
     topojson-client "^3.1.0"
 
 "@elastic/eui@^95.0.0":
-  version "95.10.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-95.10.0.tgz#c8ab6680792c0e2c70b4db0d044bde56c7a78f0d"
-  integrity sha512-m4XfTFDVvqWzs6p86k+DHITJH5OQQH3W10mqbSIU8O0jaBXIs4R4PwKuqllAL4WweAnmm2rdKeLpHqYWFekzlA==
+  version "95.10.1"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-95.10.1.tgz#f3fb356ad49ba45e42981e39748693ba392567fe"
+  integrity sha512-1kqyx/NfiQE/bKMf1E3uJEpYZnQnPBrI5zO0l2FB+fs7Naf7wT7zq1VFRzNLn/r1x6mnou8wJ+VlouHCI+prLw==
   dependencies:
     "@hello-pangea/dnd" "^16.6.0"
     "@types/lodash" "^4.14.202"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [fix(deps): update dependency @elastic/eui to v95.10.1 (#932)](https://github.com/elastic/ems-landing-page/pull/932)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)