### PR TITLE
[v8.16] fix(deps): update dependency maplibre-gl to v4.7.0 (#938)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@turf/bbox": "7.1.0",
     "@turf/center": "7.1.0",
     "chroma-js": "3.0.0",
-    "maplibre-gl": "4.6.0",
+    "maplibre-gl": "4.7.0",
     "moment": "^2.30.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6266,10 +6266,10 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-maplibre-gl@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-4.6.0.tgz#f25113a284752162cf4444a32f395380bc2565ec"
-  integrity sha512-zobZK+fE+XM+7K81fk5pSBYWZlTGjGT0P96y2fR4DV2ry35ZBfAd0uWNatll69EgYeE+uOhN1MvEk+z1PCuyOQ==
+maplibre-gl@4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-4.7.0.tgz#9d69602f48db6cc8b0638845f5f4076bf77bf21c"
+  integrity sha512-hkt7je7NxiMQE8EpCxLWP8t6tkK6SkrMe0hIBjYd4Ar/Q7BOCILxthGmGnU993Mwmkvs2mGiXnVUSOK12DeCzg==
   dependencies:
     "@mapbox/geojson-rewind" "^0.5.2"
     "@mapbox/jsonlint-lines-primitives" "^2.0.2"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.16`:
 - [fix(deps): update dependency maplibre-gl to v4.7.0 (#938)](https://github.com/elastic/ems-landing-page/pull/938)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)