### PR TITLE
[v8.x] fix(deps): update dependency chroma-js to v3.1.1 (#948)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "7.1.0",
     "@turf/center": "7.1.0",
-    "chroma-js": "3.0.0",
+    "chroma-js": "3.1.1",
     "maplibre-gl": "4.7.0",
     "moment": "^2.30.1",
     "react": "18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3447,10 +3447,10 @@ chokidar@^3.6.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chroma-js@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-3.0.0.tgz#c19b3b728352bb02b8906c60d7c7d223d3d9b721"
-  integrity sha512-ZFn4qxtZTvRJ7XatOLgaHGJYN10LoS6T0EMsu7IVayFG5+b6Yw8wCGQL5qLgo4B+wrRZ9niCrozOQ4a584bvaA==
+chroma-js@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-3.1.1.tgz#380103ce1f8bb119be2b18303d598b3c113cf6b1"
+  integrity sha512-CGr6w73Gi86142RWqZ1RjED/CyduYw2vMTikQZUvr2jGIihnZlMo/Kzm9rYHWDP2pJc6eebwc8CkX0iteBon+A==
 
 chroma-js@^2.1.0:
   version "2.4.2"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.x`:
 - [fix(deps): update dependency chroma-js to v3.1.1 (#948)](https://github.com/elastic/ems-landing-page/pull/948)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)