### PR TITLE
[v8.x] chore(deps): update dependency babel-loader to v9.2.1 (#972)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@emotion/react": "11.13.3",
     "@eslint/eslintrc": "3.1.0",
     "@eslint/js": "9.10.0",
-    "babel-loader": "9.1.3",
+    "babel-loader": "9.2.1",
     "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-plugin-inline-react-svg": "2.0.2",
     "babel-plugin-react-docgen": "4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2974,10 +2974,10 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-babel-loader@9.1.3:
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-9.1.3.tgz#3d0e01b4e69760cc694ee306fe16d358aa1c6f9a"
-  integrity sha512-xG3ST4DglodGf8qSwv0MdeWLhrDsw/32QMdTO5T1ZIp9gQur0HkCyFs7Awskr10JKXFXwpAhiCuYX5oGXnRGbw==
+babel-loader@9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-9.2.1.tgz#04c7835db16c246dd19ba0914418f3937797587b"
+  integrity sha512-fqe8naHt46e0yIdkjUZYqddSXfej3AHajX+CSO5X7oy0EmPc6o5Xh+RClNoHjnieWz9AW4kZxW9yyFMhVB1QLA==
   dependencies:
     find-cache-dir "^4.0.0"
     schema-utils "^4.0.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.x`:
 - [chore(deps): update dependency babel-loader to v9.2.1 (#972)](https://github.com/elastic/ems-landing-page/pull/972)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)