### PR TITLE
[v9.0] fix(deps): update dependency maplibre-gl to v4.7.1 (#984)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@turf/bbox": "7.1.0",
     "@turf/center": "7.1.0",
     "chroma-js": "3.1.1",
-    "maplibre-gl": "4.7.0",
+    "maplibre-gl": "4.7.1",
     "moment": "^2.30.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6273,10 +6273,10 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-maplibre-gl@4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-4.7.0.tgz#9d69602f48db6cc8b0638845f5f4076bf77bf21c"
-  integrity sha512-hkt7je7NxiMQE8EpCxLWP8t6tkK6SkrMe0hIBjYd4Ar/Q7BOCILxthGmGnU993Mwmkvs2mGiXnVUSOK12DeCzg==
+maplibre-gl@4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-4.7.1.tgz#06a524438ee2aafbe8bcd91002a4e01468ea5486"
+  integrity sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==
   dependencies:
     "@mapbox/geojson-rewind" "^0.5.2"
     "@mapbox/jsonlint-lines-primitives" "^2.0.2"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v9.0`:
 - [fix(deps): update dependency maplibre-gl to v4.7.1 (#984)](https://github.com/elastic/ems-landing-page/pull/984)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)