### PR TITLE
[v7.17] fix(deps): update dependency @elastic/eui to v96 (#1039)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
     "@elastic/ems-client": "7.17.3",
-    "@elastic/eui": "^95.0.0",
+    "@elastic/eui": "^96.0.0",
     "@emotion/css": "^11.10.6",
     "@hello-pangea/dnd": "16.6.0",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",

--- a/public/main.css
+++ b/public/main.css
@@ -1,4 +1,3 @@
-@import "../node_modules/@elastic/eui/dist/eui_theme_light.css";
 @import "../node_modules/maplibre-gl/dist/maplibre-gl.css";
 
 body {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1625,10 +1625,10 @@
     semver "7.6.2"
     topojson-client "^3.1.0"
 
-"@elastic/eui@^95.0.0":
-  version "95.12.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-95.12.0.tgz#862f2be8b72248a62b40704b9e62f2f5d7d43853"
-  integrity sha512-SW4ru97FY2VitSqyCgURrM5OMk1W+Ww12b6S+VZN5ex50aNT296DfED/ByidlYaAoVihqjZuoB3HlQBBXydFpA==
+"@elastic/eui@^96.0.0":
+  version "96.1.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-96.1.0.tgz#cd75f2a7a2ca07df6fb8f9af985dff3f05172fb6"
+  integrity sha512-LmB92xr704Dfth9UnxCOm4b63lghb/7svXsnd0zcbSQA/BPqktUm1evZjWYIWFIek5D4JI4dmM+ygXLWdKSM+Q==
   dependencies:
     "@hello-pangea/dnd" "^16.6.0"
     "@types/lodash" "^4.14.202"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [fix(deps): update dependency @elastic/eui to v96 (#1039)](https://github.com/elastic/ems-landing-page/pull/1039)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)