### PR TITLE
[v8.15] chore(deps): update dependency globals to v15.11.0 (#1056)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint": "9.12.0",
     "eslint-plugin-react": "7.37.1",
     "file-loader": "6.2.0",
-    "globals": "15.10.0",
+    "globals": "15.11.0",
     "handlebars": "4.7.8",
     "handlebars-loader": "1.7.3",
     "html-webpack-plugin": "5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5114,10 +5114,10 @@ global-prefix@^4.0.0:
     kind-of "^6.0.3"
     which "^4.0.0"
 
-globals@15.10.0:
-  version "15.10.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-15.10.0.tgz#a7eab3886802da248ad8b6a9ccca6573ff899c9b"
-  integrity sha512-tqFIbz83w4Y5TCbtgjZjApohbuh7K9BxGYFm7ifwDR240tvdb7P9x+/9VvUKlmkPoiknoJtanI8UOrqxS3a7lQ==
+globals@15.11.0:
+  version "15.11.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-15.11.0.tgz#b96ed4c6998540c6fb824b24b5499216d2438d6e"
+  integrity sha512-yeyNSjdbyVaWurlwCpcA6XNBrHTMIeDdj0/hnvX/OLJ9ekOXYbLsLinH/MucQyGvNnXhidTdNhTtJaffL2sMfw==
 
 globals@^11.1.0:
   version "11.12.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.15`:
 - [chore(deps): update dependency globals to v15.11.0 (#1056)](https://github.com/elastic/ems-landing-page/pull/1056)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)