### PR TITLE
[v8.x] fix(deps): update dependency @elastic/eui to v97 (#1057)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
     "@elastic/ems-client": "8.5.3",
-    "@elastic/eui": "^96.0.0",
+    "@elastic/eui": "^97.0.0",
     "@emotion/css": "^11.10.6",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,10 +1591,10 @@
     semver "^7.6.2"
     topojson-client "^3.1.0"
 
-"@elastic/eui@^96.0.0":
-  version "96.1.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-96.1.0.tgz#cd75f2a7a2ca07df6fb8f9af985dff3f05172fb6"
-  integrity sha512-LmB92xr704Dfth9UnxCOm4b63lghb/7svXsnd0zcbSQA/BPqktUm1evZjWYIWFIek5D4JI4dmM+ygXLWdKSM+Q==
+"@elastic/eui@^97.0.0":
+  version "97.0.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-97.0.0.tgz#b7828b8818de1328e47b4c47024d8455a5795f23"
+  integrity sha512-ha7oer/0ou0MnZMgwZzqKE97tx/IPhQtb04nNLZvwOiBAH+ANtUqohYSM/3VxLuJT13cxbsLC2CLT0Ktcibo4w==
   dependencies:
     "@hello-pangea/dnd" "^16.6.0"
     "@types/lodash" "^4.14.202"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.x`:
 - [fix(deps): update dependency @elastic/eui to v97 (#1057)](https://github.com/elastic/ems-landing-page/pull/1057)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)