### PR TITLE
[v9.0] fix(deps): update dependency chroma-js to v3.1.2 (#1069)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@turf/bbox": "7.1.0",
     "@turf/center": "7.1.0",
-    "chroma-js": "3.1.1",
+    "chroma-js": "3.1.2",
     "maplibre-gl": "4.7.1",
     "moment": "^2.30.1",
     "react": "18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3472,10 +3472,10 @@ chokidar@^3.6.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chroma-js@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-3.1.1.tgz#380103ce1f8bb119be2b18303d598b3c113cf6b1"
-  integrity sha512-CGr6w73Gi86142RWqZ1RjED/CyduYw2vMTikQZUvr2jGIihnZlMo/Kzm9rYHWDP2pJc6eebwc8CkX0iteBon+A==
+chroma-js@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-3.1.2.tgz#cfb807045182228574eae5380587cdb830e985d6"
+  integrity sha512-IJnETTalXbsLx1eKEgx19d5L6SRM7cH4vINw/99p/M11HCuXGRWL+6YmCm7FWFGIo6dtWuQoQi1dc5yQ7ESIHg==
 
 chroma-js@^2.1.0:
   version "2.4.2"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v9.0`:
 - [fix(deps): update dependency chroma-js to v3.1.2 (#1069)](https://github.com/elastic/ems-landing-page/pull/1069)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)