### PR TITLE
[v9.0] chore(deps): update dependency html-webpack-plugin to v5.6.2 (#1085)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "globals": "15.11.0",
     "handlebars": "4.7.8",
     "handlebars-loader": "1.7.3",
-    "html-webpack-plugin": "5.6.0",
+    "html-webpack-plugin": "5.6.2",
     "husky": "9.1.6",
     "node-fetch": "3.3.2",
     "node-polyfill-webpack-plugin": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5366,10 +5366,10 @@ html-void-elements@^1.0.0:
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"
   integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
 
-html-webpack-plugin@5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz#50a8fa6709245608cb00e811eacecb8e0d7b7ea0"
-  integrity sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==
+html-webpack-plugin@5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.6.2.tgz#174a67c8e55aa3fa2ba94c8e8e42894bfe4978ea"
+  integrity sha512-q7xp/FO9RGBVoTKNItkdX1jKLscLFkgn/dLVFNYbHVbfHLBk6DYW5nsQ8kCzIWcgKP/kUBocetjvav6lD8YfCQ==
   dependencies:
     "@types/html-minifier-terser" "^6.0.0"
     html-minifier-terser "^6.0.2"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v9.0`:
 - [chore(deps): update dependency html-webpack-plugin to v5.6.2 (#1085)](https://github.com/elastic/ems-landing-page/pull/1085)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)