### PR TITLE
[v7.17] [skip-ci] update backport config for CI (#1127)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,10 +1,17 @@
 {
-  "upstream": "elastic/ems-landing-page",
-  "branches": [
-    { "name": "v8.14", "checked": true },
-    { "name": "v8.13", "checked": true },
-    { "name": "v7.17", "checked": true }
+  "repoOwner": "elastic",
+  "repoName": "elastic/ems-landing-page",
+  "targetBranches": [
+    "v9.0",
+    "v8.x",
+    "v8.17",
+    "v8.16",
+    "v8.15",
+    "v7.17"
   ],
-  "labels": ["backport"],
-  "multipleCommits": true
+  "targetPRLabels": ["backport"],
+  "commitConflicts": true,
+  "autoMerge": true,
+  "autoMergeMethod": "squash",
+  "fork": false
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v7.17`:
 - [[skip-ci] update backport config for CI (#1127)](https://github.com/elastic/ems-landing-page/pull/1127)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)