### PR TITLE
[v8.15] [skip-ci] fix repoName (#1134)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,6 @@
 {
   "repoOwner": "elastic",
-  "repoName": "elastic/ems-landing-page",
+  "repoName": "ems-landing-page",
   "targetBranches": [
     "v9.0",
     "v8.x",


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.15`:
 - [[skip-ci] fix repoName (#1134)](https://github.com/elastic/ems-landing-page/pull/1134)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)