### PR TITLE
[v8.x] [skip-ci] Add label mapping to the backport configuration (#1141) | [skip-ci] fix label mapping (#1142)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,14 +1,18 @@
 {
   "repoOwner": "elastic",
   "repoName": "ems-landing-page",
-  "targetBranches": [
-    "v9.0",
+  "targetBranchChoices": [
+    "master",
     "v8.x",
-    "v8.17",
     "v8.16",
     "v8.15",
     "v7.17"
   ],
+  "branchLabelMapping": {
+    "^v9.0$": "master",
+    "^v8.17$": "8.x",
+    "^v(\\d+).(\\d+).\\d+$": "$1.$2"
+  },
   "targetPRLabels": ["backport"],
   "commitConflicts": true,
   "autoMerge": true,

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -10,8 +10,8 @@
   ],
   "branchLabelMapping": {
     "^v9.0$": "master",
-    "^v8.17$": "8.x",
-    "^v(\\d+).(\\d+).\\d+$": "$1.$2"
+    "^v8.17$": "v8.x",
+    "^v(\\d+).(\\d+)$": "v$1.$2"
   },
   "targetPRLabels": ["backport"],
   "commitConflicts": true,


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.x`:
 - [[skip-ci] Add label mapping to the backport configuration (#1141)](https://github.com/elastic/ems-landing-page/pull/1141)
 - [[skip-ci] fix label mapping (#1142)](https://github.com/elastic/ems-landing-page/pull/1142)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)