### PR TITLE
[skip-ci] New github actions to sync master and 8.x with v9.0 and v8.17

### DIFF
--- a/.github/workflows/sync_8.17.yml
+++ b/.github/workflows/sync_8.17.yml
@@ -1,0 +1,24 @@
+name: Sync v8.x with v8.17
+on:
+  push:
+    branches:
+      - v8.x
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Syncing branches
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Opening pull request
+        id: pull
+        uses: tretuna/sync-branches@1.4.0
+        with:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          FROM_BRANCH: "v8.x"
+          TO_BRANCH: "v8.17"

--- a/.github/workflows/sync_9.0.yml
+++ b/.github/workflows/sync_9.0.yml
@@ -1,0 +1,24 @@
+name: Sync master with v9.0
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Syncing branches
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Opening pull request
+        id: pull
+        uses: tretuna/sync-branches@1.4.0
+        with:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          FROM_BRANCH: "master"
+          TO_BRANCH: "v9.0"


### PR DESCRIPTION
Adds two new github actions that will open PRs to keep:

* `v9.0` in sync with `master`
* `v8.17` in sync with `v8.x`

This will require an additional step when releasing new minors that will need to be documented later when the procedure is clear.