### PR TITLE
[v8.15] [skip-ci] Ignore backport action for sync PRs #2 (#1221)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -3,6 +3,9 @@ name: Automatic backport action
 on:
   pull_request_target:
     types: ["labeled", "closed"]
+    branches-ignore:
+      - v8.17
+      - v9.0
 
 jobs:
   backport:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.15`:
 - [[skip-ci] Ignore backport action for sync PRs #2 (#1221)](https://github.com/elastic/ems-landing-page/pull/1221)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)