### PR TITLE
Bumps to 8.18

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -4,13 +4,13 @@
   "targetBranchChoices": [
     "master",
     "v8.x",
+    "v8.17",
     "v8.16",
-    "v8.15",
     "v7.17"
   ],
   "branchLabelMapping": {
     "^v9.0$": "master",
-    "^v8.17$": "v8.x",
+    "^v8.18$": "v8.x",
     "^v(\\d+).(\\d+)$": "v$1.$2"
   },
   "targetPRLabels": ["backport"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ems_landing_page",
-  "version": "8.17.0",
+  "version": "8.18.0",
   "description": "",
   "main": "main.js",
   "devDependencies": {

--- a/public/config.json
+++ b/public/config.json
@@ -2,7 +2,7 @@
   "default": "production",
   "serviceName": "Elastic Maps Service",
   "SUPPORTED_EMS": {
-    "emsVersion": "8.17.0",
+    "emsVersion": "8.18.0",
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   ],
   "labels": [
     "dependencies",
+    "v8.18",
     "v8.17",
     "v8.16",
     "v7.17"


### PR DESCRIPTION
Bumps the master branch to 8.18 following the [New release docs](https://github.com/elastic/ems-landing-page/blob/4ac92161e4bc8e1eb82a0d98ea14ccf047ad21e2/CONTRIBUTING.md#new-releases)

- Updates the package.json to 8.18.0
- Updates the EMS version in the config file to 8.18
- Adds the 8.18 branch to the backport
- Updates renovate.json

>[!Important]
> In preparation of the new `v9.x` series. This PR is against the `v8.x` branch

>[!Important]
> After this PR is merged a sibling `v8.18` branch synchronized with `v8.x` will be created to deploy a new version in the `v8.18` route in our GCP buckets.

A follow up PR will be required to update the Github Action that synchronizes `v8.x` with the new branch.

