### PR TITLE
[ci] Get Borealis also for tag builds

### DIFF
--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -14,7 +14,7 @@ echo "--- :gear: Building"
 
 export EUI_THEME="amsterdam"
 
-if [[ "${BUILDKITE_BRANCH}" == "v9.0" ]]; then
+if [[ "${BUILDKITE_BRANCH}" == v9.0* ]]; then
   export EUI_THEME="borealis"
   echo "Switching to 🌠 Borealis 🌠 theme"
 fi


### PR DESCRIPTION
Small fix to get the `EUI_THEME` correctly set up for production deployments on the `v9.0` branch.

