### PR TITLE
[v9.0] chore(config): migrate config renovate.json (#1563)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,10 +26,10 @@
       "automerge": true
     },
     {
-      "matchPackagePatterns": [
-        "elastic/eui"
-      ],
-      "groupName": "Elastic EUI"
+      "groupName": "Elastic EUI",
+      "matchPackageNames": [
+        "/elastic/eui/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v9.0`:
 - [chore(config): migrate config renovate.json (#1563)](https://github.com/elastic/ems-landing-page/pull/1563)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)