### PR TITLE
[v8.x] chore(config): migrate config renovate.json (#1563)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,10 +25,10 @@
       "automerge": true
     },
     {
-      "matchPackagePatterns": [
-        "elastic/eui"
-      ],
-      "groupName": "Elastic EUI"
+      "groupName": "Elastic EUI",
+      "matchPackageNames": [
+        "/elastic/eui/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.x`:
 - [chore(config): migrate config renovate.json (#1563)](https://github.com/elastic/ems-landing-page/pull/1563)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)