### PR TITLE
[v8.16] chore(config): migrate config renovate.json (#1563)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,12 @@
         "devDependencies"
       ],
       "automerge": true
+    },
+    {
+      "groupName": "Elastic EUI",
+      "matchPackageNames": [
+        "/elastic/eui/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.16`:
 - [chore(config): migrate config renovate.json (#1563)](https://github.com/elastic/ems-landing-page/pull/1563)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)