### PR TITLE
[v8.x] [skip-ci] Update github actions with 8.19 and 9.1 branches (#1560)

### DIFF
--- a/.github/workflows/add_backport_label.yml
+++ b/.github/workflows/add_backport_label.yml
@@ -3,8 +3,8 @@ name: Force backport label for sync PRs
 on:
   pull_request_target:
     branches:
-      - v9.0
-      - v8.18
+      - v9.1
+      - v8.19
     types:
       - opened
       - reopened

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,8 +4,8 @@ on:
   pull_request_target:
     types: ["labeled", "closed"]
     branches-ignore:
-      - v8.18
-      - v9.0
+      - v8.19
+      - v9.1
 
 jobs:
   backport:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.x`:
 - [[skip-ci] Update github actions with 8.19 and 9.1 branches (#1560)](https://github.com/elastic/ems-landing-page/pull/1560)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)