### PR TITLE
[v8.18] chore(deps): update actions/setup-node digest to 49933ea (#1884)

### DIFF
--- a/.github/workflows/sync_8.18.yml
+++ b/.github/workflows/sync_8.18.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set up Node
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 12
       - name: Opening pull request

--- a/.github/workflows/sync_9.0.yml
+++ b/.github/workflows/sync_9.0.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set up Node
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 12
       - name: Opening pull request


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.18`:
 - [chore(deps): update actions/setup-node digest to 49933ea (#1884)](https://github.com/elastic/ems-landing-page/pull/1884)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)