### PR TITLE
[v8.18] fix(deps): update elastic eui (#2298)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   "dependencies": {
     "@elastic/datemath": "5.0.3",
     "@elastic/ems-client": "8.6.3",
-    "@elastic/eui": "106.2.0",
-    "@elastic/eui-theme-borealis": "3.3.0",
+    "@elastic/eui": "106.3.0",
+    "@elastic/eui-theme-borealis": "3.3.1",
     "@emotion/css": "11.13.5",
     "@mapbox/mapbox-gl-rtl-text": "0.2.3",
     "@turf/bbox": "7.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1668,26 +1668,26 @@
     semver "^7.6.3"
     topojson-client "^3.1.0"
 
-"@elastic/eui-theme-borealis@3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui-theme-borealis/-/eui-theme-borealis-3.3.0.tgz#c2583fcc068d560bbd6c4cdc830bb6da202e983e"
-  integrity sha512-zWOMUtuWRcOYzN6pVgIRAqtQgUi4AJmjNRRvt1lRIwrivjo41hxGFqfZuiZvGMgrSNM6OFqKMqRZBZV88PMxUA==
+"@elastic/eui-theme-borealis@3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@elastic/eui-theme-borealis/-/eui-theme-borealis-3.3.1.tgz#cbc1bcdf68277235e0ab1e1a19ec3a5511258dd6"
+  integrity sha512-atrYq78/s28qaP+eryCNMcW0FDHKWNdE4ltxmEEmvrUtqpA0NE55xeV6sTW7zld66aNpbooYqpgLSJqs9WafRg==
 
-"@elastic/eui-theme-common@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui-theme-common/-/eui-theme-common-3.1.0.tgz#e70b881bf4d2801d38f515982a32d702e63a7213"
-  integrity sha512-hobhxba5v+7fJeO5j6u12KVMoPr47WpqzHi+p9JntMegD2MeyEuz2a8Z204VPJvEbzQuat9Glgjst5nCxN6sKw==
+"@elastic/eui-theme-common@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui-theme-common/-/eui-theme-common-4.0.0.tgz#d3f10cc42f754923ae23cee9a1b62d4345157843"
+  integrity sha512-0X9KFVpQnyk4KsWD5W8fzzZbCud25XJ6z2J03qka0mwh4qGy/XWIiGflBC1BH1BZYu71olnaMKaSJQliY3LZlQ==
   dependencies:
     "@types/lodash" "^4.14.202"
     chroma-js "^2.4.2"
     lodash "^4.17.21"
 
-"@elastic/eui@106.2.0":
-  version "106.2.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-106.2.0.tgz#9513b959681fb471eaf6ba454950cd5b575a1959"
-  integrity sha512-I4JQChwHAZC4W0PDQzfh/26WhdHCzc/7CTFOqp4sgLpX1hoG3jCJDQMDVQy6d7MFWWYg2RWpfk3qTHXapwAlBw==
+"@elastic/eui@106.3.0":
+  version "106.3.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-106.3.0.tgz#3dbe8135b8b1cc36def41b39b14fb2a243b7dde0"
+  integrity sha512-TkeGP7Eq0v/LKIZMbw0HcpDd4Bn+xgkaEZLck+nmYFd5cKxVr4l6wCXFVfNSc/xPrqsvSNHVclC+n0P9EWWdHQ==
   dependencies:
-    "@elastic/eui-theme-common" "3.1.0"
+    "@elastic/eui-theme-common" "4.0.0"
     "@elastic/prismjs-esql" "^1.1.0"
     "@hello-pangea/dnd" "^16.6.0"
     "@types/lodash" "^4.14.202"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v8.18`:
 - [fix(deps): update elastic eui (#2298)](https://github.com/elastic/ems-landing-page/pull/2298)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)