### PR TITLE
[v9.1] chore(deps): update actions/checkout action to v5 (#2320)

### DIFF
--- a/.github/workflows/sync_9.yml
+++ b/.github/workflows/sync_9.yml
@@ -10,7 +10,7 @@ jobs:
     name: Syncing branches
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v9.1`:
 - [chore(deps): update actions/checkout action to v5 (#2320)](https://github.com/elastic/ems-landing-page/pull/2320)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)