### PR TITLE
[8.x] Fix the use of a ref

### DIFF
--- a/public/js/components/map.js
+++ b/public/js/components/map.js
@@ -38,11 +38,12 @@ export class Map extends Component {
     this._overlayFillHighlightId = 'overlay-fill-highlight-layer';
     this._tmsSourceId = 'vector-tms-source';
     this._tmsLayerId = 'vector-tms-layer';
+    this._mapRef = React.createRef();
   }
 
   componentDidMount() {
     this._maplibreMap = new maplibre.Map({
-      container: this.refs.mapContainer,
+      container: this._mapRef.current,
       style: {
         version: 8,
         sources: {},
@@ -260,6 +261,6 @@ export class Map extends Component {
   }
 
   render() {
-    return (<div className="mapContainer" ref="mapContainer" />);
+    return (<div className="mapContainer" ref={this._mapRef} />);
   }
 }


### PR DESCRIPTION
The globe projection code #2052 fixed also an issue in preparation of the upgrade to React 19, but it was not backported to the 8.x or 7.17 branches. When we upgraded to React 19 #1349 we broke `8.x` branches (it was not backported to v7.17).

This only breaks at runtime, so our CI checks passed, but the error was not found since there are no integration tests for this repo.

This issue has not been surfaced in our monitors because it has not been deployed to production and is affecting our staging and development environments without triggering alerts (this should be fixed as well).

* https://maps-staging.elastic.co/v8.19/
* https://maps-staging.elastic.co/v8.18/


