### PR TITLE
[v8.17] [8.x] Fix the use of a ref (#2435)

### DIFF
--- a/public/js/components/map.js
+++ b/public/js/components/map.js
@@ -38,11 +38,12 @@ export class Map extends Component {
     this._overlayFillHighlightId = 'overlay-fill-highlight-layer';
     this._tmsSourceId = 'vector-tms-source';
     this._tmsLayerId = 'vector-tms-layer';
+    this._mapRef = React.createRef();
   }
 
   componentDidMount() {
     this._maplibreMap = new maplibre.Map({
-      container: this.refs.mapContainer,
+      container: this._mapRef.current,
       style: {
         version: 8,
         sources: {},
@@ -260,6 +261,6 @@ export class Map extends Component {
   }
 
   render() {
-    return (<div className="mapContainer" ref="mapContainer" />);
+    return (<div className="mapContainer" ref={this._mapRef} />);
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `v8.19` to `v8.17`:
 - [[8.x] Fix the use of a ref (#2435)](https://github.com/elastic/ems-landing-page/pull/2435)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)