### PR TITLE
chore: bump version to 9.5

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,12 +3,13 @@
   "repoName": "ems-landing-page",
   "targetBranchChoices": [
     "master",
+    "v9.4",
     "v9.3",
     "v9.2",
     "v8.19"
   ],
   "branchLabelMapping": {
-    "^v9.4$": "master",
+    "^v9.5$": "master",
     "^v(\\d+).(\\d+)$": "v$1.$2"
   },
   "targetPRLabels": ["backport"],

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,6 +8,7 @@ on:
       - v9.2
       - v9.3
       - v9.4
+      - v9.5
 
 jobs:
   backport:

--- a/.github/workflows/sync_9.yml
+++ b/.github/workflows/sync_9.yml
@@ -1,4 +1,4 @@
-name: Sync master with v9.4
+name: Sync master with v9.5
 on:
   push:
     branches:
@@ -21,4 +21,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "master"
-          TO_BRANCH: "v9.4"
+          TO_BRANCH: "v9.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ems_landing_page",
-  "version": "9.4.0",
+  "version": "9.5.0",
   "description": "",
   "main": "main.js",
   "devDependencies": {

--- a/public/config.json
+++ b/public/config.json
@@ -2,7 +2,7 @@
   "default": "production",
   "serviceName": "Elastic Maps Service",
   "SUPPORTED_EMS": {
-    "emsVersion": "9.4.0",
+    "emsVersion": "9.5.0",
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   ],
   "baseBranches": [
     "master",
+    "v9.4",
     "v9.3",
     "v9.2",
     "v8.19"
@@ -57,9 +58,19 @@
       "allowedVersions": "3.x"
     },
     {
-      "description": "Add branch-specific label for master/v9.4",
+      "description": "Add branch-specific label for master/v9.5",
       "matchBaseBranches": [
         "master"
+      ],
+      "labels": [
+        "dependencies",
+        "v9.5"
+      ]
+    },
+    {
+      "description": "Add branch-specific label for v9.4",
+      "matchBaseBranches": [
+        "v9.4"
       ],
       "labels": [
         "dependencies",
@@ -67,7 +78,7 @@
       ]
     },
     {
-      "description": "Add branch-specific label for v9.2",
+      "description": "Add branch-specific label for v9.3",
       "matchBaseBranches": [
         "v9.3"
       ],


### PR DESCRIPTION
Branch 9.5 was from master and ready https://github.com/elastic/ems-landing-page/tree/v9.5

## Summary

- Bumps `package.json` and `public/config.json` version from `9.4.0` to `9.5.0`
- Adds `v9.4` to backport target branches and renovate base branches
- Updates `sync_9.yml` workflow to sync master → `v9.5`
- Updates `backport.yml` to ignore `v9.5` branch
- Updates `renovate.json` labels for master/v9.5 and adds v9.4 branch label rule

Follows the same pattern as #2860 (9.3 → 9.4 bump).

## Test plan

- [x] `yarn build-unsafe` passes (lint + webpack)
- [x] `yarn test` — all 5 Playwright tests pass (vector and tile v9.5 manifests confirmed live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)