### PR TITLE
fix(test): update color picker selector for EUI v114

### DIFF
--- a/tests/ems-landing-page.spec.ts
+++ b/tests/ems-landing-page.spec.ts
@@ -226,7 +226,7 @@ test.describe('EMS Landing Page', () => {
     await page.waitForLoadState('networkidle');
 
     // Find and click the color picker input to open the popover
-    const colorPickerInput = page.getByRole('textbox', { name: /color options/i });
+    const colorPickerInput = page.getByRole('textbox', { name: /pick a color/i });
     await expect(colorPickerInput).toBeVisible();
     await colorPickerInput.click();
 


### PR DESCRIPTION
## Summary
- Fix failing e2e test "Apply color filter to basemap" on master
- EUI v114's `EuiColorPicker` inside `EuiFormRow` with `label="Pick a color"` gives the input an accessible name of "Pick a color", not "color options"
- Update selector from `/color options/i` to `/pick a color/i`

## Test plan
- [ ] CI e2e tests pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)