### PR TITLE
chore: remove redundant lodash resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "resolutions": {
     "**/yaml": "^2.8.0",
     "**/semver": "^7.7.2",
-    "**/lodash": "^4.17.23",
     "**/@babel/runtime": "^7.26.10"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Removes the `**/lodash` entry from `resolutions` in `package.json`
- All lodash dependents (`@elastic/ems-client`, `@elastic/eui`, etc.) already request `^4.17.21`, which naturally resolves to `4.18.0` (the latest 4.x) — the `^4.17.23` resolution was a no-op
- Confirmed via `yarn why lodash` and the lock file; no version change results from removing it

## Test plan

- [ ] `yarn install` produces no changes to `yarn.lock`
- [ ] `yarn build-unsafe` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)