### PR TITLE
Fix staging deployments for versioned branches

### DIFF
--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -23,6 +23,11 @@ else
   echo "Using 🌠 Borealis 🌠 theme"
 fi
 
+if [[ "${BUILDKITE_BRANCH}" != "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]] ; then
+  export ASSET_PATH="/${BUILDKITE_BRANCH}/"
+  echo "Asset base path: ${ASSET_PATH}"
+fi
+
 if [[ -n ${BUILDKITE+x} ]] ; then
   yarn build
 else

--- a/scripts/test-remote.mjs
+++ b/scripts/test-remote.mjs
@@ -99,7 +99,8 @@ console.log('');
 const results = [];
 
 for (const version of versions) {
-  const testUrl = version === 'master' ? baseUrl : `${baseUrl}/${version}`;
+  const url = version === 'master' ? baseUrl : `${baseUrl}/${version}`;
+  const testUrl = url.endsWith('/') ? url : `${url}/`;
   console.log('─'.repeat(64));
   console.log(`Testing: ${testUrl}`);
   console.log('─'.repeat(64));

--- a/tests/ems-landing-page.spec.ts
+++ b/tests/ems-landing-page.spec.ts
@@ -123,20 +123,20 @@ test.describe('EMS Landing Page', () => {
   });
 
   test('Page loads successfully', async ({ page }) => {
-    const response = await page.goto('/');
+    const response = await page.goto('./');
 
     expect(response?.status()).toBe(200);
   });
 
   test('Has title', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('./');
     await expect(page).toHaveTitle(/Elastic Maps Service/i);
   });
 
   test('Visual comparison of the initial full page', async ({ page }) => {
     test.skip(skipVisualTests, 'Visual tests skipped for remote/staging URLs');
 
-    await page.goto('/');
+    await page.goto('./');
 
     // Wait for the page to be fully loaded
     await page.waitForLoadState('networkidle');
@@ -148,7 +148,7 @@ test.describe('EMS Landing Page', () => {
   });
   
   test('Switch between basemaps', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('./');
     await expect(page.getByLabel('Map', { exact: true })).toBeVisible();
 
     const classicMap = 'Classic';
@@ -162,7 +162,7 @@ test.describe('EMS Landing Page', () => {
   });
 
   test('Load a dataset', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('./');
     await page.getByRole('button', { name: 'Brazil States' }).click();
 
     await page.getByText('BR-AM').click();
@@ -178,7 +178,7 @@ test.describe('EMS Landing Page', () => {
   });
 
   test('Change basemap language', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('./');
     
     // Wait for the page to be fully loaded
     await page.waitForLoadState('networkidle');
@@ -222,7 +222,7 @@ test.describe('EMS Landing Page', () => {
   });
 
   test('Apply color filter to basemap', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('./');
     await page.waitForLoadState('networkidle');
 
     // Find and click the color picker input to open the popover


### PR DESCRIPTION
## Summary

The Vite migration broke all versioned branch staging deployments (v9.4, v9.3, v9.2, v8.19). Two related issues:

**1. Build: missing `ASSET_PATH` for subdirectory deployments**

`vite.config.js` supports `base: process.env.ASSET_PATH || '/'` but `build.sh` never sets `ASSET_PATH`. Versioned branches deploy to subdirectories (e.g. `/v9.2/`), so assets built with base `/` resolve to the bucket root instead of the version path, causing 404s on all assets. Master was unaffected because `upload.sh` syncs it to the bucket root in addition to `/master/`.

Fix: set `ASSET_PATH=/${BUILDKITE_BRANCH}/` for non-default branches before the Vite build runs.

**2. Tests: `page.goto('/')` ignores versioned base URLs**

The `test:staging` script sets `PLAYWRIGHT_BASE_URL` to e.g. `https://maps-staging.elastic.co/v9.2`, but all tests use `page.goto('/')`. Playwright resolves this with the `URL` constructor: `new URL('/', 'https://maps-staging.elastic.co/v9.2')` → `https://maps-staging.elastic.co/`, stripping the version path. Every version was silently testing the root (master) deployment, so the broken sites were never caught.

Fix: use `page.goto('./')` (relative resolution) and ensure `testUrl` ends with a trailing slash so the version path is preserved.

## Test plan

- [ ] Run `yarn test:staging` and confirm versioned branches now correctly fail (until this fix is backported and redeployed)
- [ ] Backport to v9.4, v9.3, v9.2, v8.19
- [ ] After backport CI runs, verify staging sites load at their versioned URLs

Made with [Cursor](https://cursor.com)