### PR TITLE
fix(test): broaden e2e selectors to support older EUI/EMS versions

### DIFF
--- a/tests/ems-landing-page.spec.ts
+++ b/tests/ems-landing-page.spec.ts
@@ -152,7 +152,7 @@ test.describe('EMS Landing Page', () => {
     await expect(page.getByLabel('Map', { exact: true })).toBeVisible();
 
     const classicMap = 'Classic';
-    const darkMap = 'Dark Blue';
+    const darkMap = /^Dark( Blue)?$/;
     await page.getByRole('button', { name: classicMap, exact: true }).click();
     await page.getByRole('button', { name: darkMap }).click();
 
@@ -226,7 +226,7 @@ test.describe('EMS Landing Page', () => {
     await page.waitForLoadState('networkidle');
 
     // Find and click the color picker input to open the popover
-    const colorPickerInput = page.getByRole('textbox', { name: /pick a color/i });
+    const colorPickerInput = page.getByRole('textbox', { name: /pick a color|color options/i });
     await expect(colorPickerInput).toBeVisible();
     await colorPickerInput.click();
 


### PR DESCRIPTION
## Summary

The `test:staging` script runs master's test file against all versioned staging URLs, but two selectors fail on v8.19 (EUI 107) because labels changed between EUI versions:

- **Basemap button**: "Dark" (EUI 107) vs "Dark Blue" (EUI 114) -- use `/^Dark( Blue)?$/` to match both
- **Color picker textbox**: "color options" (EUI 107) vs "pick a color" (EUI 114) -- use `/pick a color|color options/i` to match both

## Test plan

- [x] Run `yarn test:staging` and confirm v8.19 "Switch between basemaps" and "Apply color filter to basemap" tests pass

Made with [Cursor](https://cursor.com)