### PR TITLE
fix(test): include synced version branches in staging/production tests

### DIFF
--- a/scripts/test-remote.mjs
+++ b/scripts/test-remote.mjs
@@ -32,8 +32,17 @@ function getDefaultVersions() {
   const backportrc = JSON.parse(readFileSync(new URL('../.backportrc.json', import.meta.url), 'utf8'));
   const versions = ['master'];
 
+  if (backportrc.branchLabelMapping) {
+    for (const [pattern, target] of Object.entries(backportrc.branchLabelMapping)) {
+      const match = pattern.match(/^\^(v\d+\.\d+)\$$/);
+      if (match && !versions.includes(match[1])) {
+        versions.push(match[1]);
+      }
+    }
+  }
+
   for (const branch of backportrc.targetBranchChoices) {
-    if (branch !== 'master') {
+    if (branch !== 'master' && !versions.includes(branch)) {
       versions.push(branch);
     }
   }


### PR DESCRIPTION
## Summary

The `test:staging` and `test:production` scripts derive their version list from `.backportrc.json` `targetBranchChoices`, which only includes backport targets. This misses deployed branches like `v9.5` that are synced from master via GitHub Actions rather than being backport targets.

Now also extracts version branches from `branchLabelMapping` (e.g. `^v9.5$` → `master`), so the test list becomes: `master, v9.5, v9.4, v9.3, v9.2, v8.19`.

This is future-proof -- when the config is updated for v9.6, the new synced branch will automatically be picked up without any test changes.

## Test plan

- [ ] Run `node scripts/test-remote.mjs --base-url https://maps-staging.elastic.co --help` and verify v9.5 appears in the default versions list
- [ ] Run `yarn test:staging` and confirm v9.5 is tested

Made with [Cursor](https://cursor.com)