### PR TITLE
fix(deps): resolve protocol-buffers-schema to ^3.6.1 (CVE-2026-5758)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "resolutions": {
     "**/yaml": "^2.8.0",
     "**/semver": "^7.7.2",
-    "**/@babel/runtime": "^7.26.10"
+    "**/@babel/runtime": "^7.26.10",
+    "**/protocol-buffers-schema": "^3.6.1"
   },
   "scripts": {
     "dev": "vite",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3504,10 +3504,10 @@ property-information@^5.0.0, property-information@^5.3.0:
   dependencies:
     xtend "^4.0.0"
 
-protocol-buffers-schema@^3.3.1:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz#77bc75a48b2ff142c1ad5b5b90c94cd0fa2efd03"
-  integrity sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==
+protocol-buffers-schema@^3.3.1, protocol-buffers-schema@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz#fd9a58a5c4e96385b964808f3ddd58f9ef18c3c8"
+  integrity sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==
 
 punycode@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
## Summary

- Adds yarn `resolutions` override forcing `protocol-buffers-schema` to `^3.6.1` across the dependency tree, replacing the vulnerable `3.6.0` reached transitively via `pbf` → `resolve-protobuf-schema`.
- Closes the Snyk finding for [CVE-2026-5758](https://nvd.nist.gov/vuln/detail/CVE-2026-5758) ([GHSA-j452-xhg8-qg39](https://github.com/advisories/GHSA-j452-xhg8-qg39), CVSS 6.5 medium, prototype pollution via `parse()`).
- ems-landing-page is **not exploitable** by this CVE: `protocol-buffers-schema` is only reachable through `pbf/bin/pbf` (codegen CLI) which uses Node `fs`/`path`. At browser runtime maplibre-gl uses pre-generated `Pbf` binary readers and never calls `parse()`. Bumping proactively to clear the Snyk SLO finding.
- Parallel fix for the same CVE on a sibling repo: elastic/ems-client#1193.

## Test plan

- [ ] `yarn install` resolves `protocol-buffers-schema@3.6.1`
- [ ] `yarn build` succeeds
- [ ] `yarn test` (Playwright) passes
- [ ] Manual smoke test of the landing page (vector tile rendering still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)