### PR TITLE
[skip-ci] Deprecate 9.2 branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -5,7 +5,6 @@
     "master",
     "v9.4",
     "v9.3",
-    "v9.2",
     "v8.19"
   ],
   "branchLabelMapping": {

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,7 +5,6 @@ on:
     types: ["labeled", "closed"]
     branches-ignore:
       - v8.19
-      - v9.2
       - v9.3
       - v9.4
       - v9.5

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,6 @@
     "master",
     "v9.4",
     "v9.3",
-    "v9.2",
     "v8.19"
   ],
   "labels": [
@@ -85,16 +84,6 @@
       "labels": [
         "dependencies",
         "v9.3"
-      ]
-    },
-    {
-      "description": "Add branch-specific label for v9.2",
-      "matchBaseBranches": [
-        "v9.2"
-      ],
-      "labels": [
-        "dependencies",
-        "v9.2"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- Removes `v9.2` from backport target branches, the backport workflow `branches-ignore` list, and Renovate `baseBranches` plus the v9.2-specific label rule.
- Mirrors #3196 (which deprecated `v9.1` and `v8.18`) on the same three files.

## Test plan

- [ ] Renovate dashboard no longer enumerates v9.2 base branch
- [ ] Backport label flow ignores merges to v9.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)