### PR TITLE
[v9.4] [skip-ci] Deprecate 9.2 branch (#3560)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -4,7 +4,6 @@
   "targetBranchChoices": [
     "master",
     "v9.3",
-    "v9.2",
     "v8.19"
   ],
   "branchLabelMapping": {

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,7 +5,6 @@ on:
     types: ["labeled", "closed"]
     branches-ignore:
       - v8.19
-      - v9.2
       - v9.3
       - v9.4
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
   "baseBranches": [
     "master",
     "v9.3",
-    "v9.2",
     "v8.19"
   ],
   "labels": [
@@ -74,16 +73,6 @@
       "labels": [
         "dependencies",
         "v9.3"
-      ]
-    },
-    {
-      "description": "Add branch-specific label for v9.2",
-      "matchBaseBranches": [
-        "v9.2"
-      ],
-      "labels": [
-        "dependencies",
-        "v9.2"
       ]
     },
     {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v9.4`:
 - [[skip-ci] Deprecate 9.2 branch (#3560)](https://github.com/elastic/ems-landing-page/pull/3560)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)