### PR TITLE
[v9.3] [skip-ci] Deprecate 9.2 branch (#3560)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,13 +3,12 @@
   "repoName": "ems-landing-page",
   "targetBranchChoices": [
     "master",
-    "v9.2",
-    "v9.1",
-    "v8.19",
-    "v8.18"
+    "v9.4",
+    "v9.3",
+    "v8.19"
   ],
   "branchLabelMapping": {
-    "^v9.3$": "master",
+    "^v9.5$": "master",
     "^v(\\d+).(\\d+)$": "v$1.$2"
   },
   "targetPRLabels": ["backport"],

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,11 +4,10 @@ on:
   pull_request_target:
     types: ["labeled", "closed"]
     branches-ignore:
-      - v8.18
       - v8.19
-      - v9.1
-      - v9.2
       - v9.3
+      - v9.4
+      - v9.5
 
 jobs:
   backport:

--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,9 @@
   ],
   "baseBranches": [
     "master",
-    "v9.2",
-    "v9.1",
-    "v8.19",
-    "v8.18"
+    "v9.4",
+    "v9.3",
+    "v8.19"
   ],
   "labels": [
     "dependencies"
@@ -40,8 +39,7 @@
     {
       "description": "Pin EUI to 107.x for v8 branches",
       "matchBaseBranches": [
-        "v8.19",
-        "v8.18"
+        "v8.19"
       ],
       "matchPackageNames": [
         "@elastic/eui"
@@ -51,8 +49,7 @@
     {
       "description": "Pin EUI theme to 3.x for v8 branches (compatible with EUI 107)",
       "matchBaseBranches": [
-        "v8.19",
-        "v8.18"
+        "v8.19"
       ],
       "matchPackageNames": [
         "@elastic/eui-theme-borealis"
@@ -60,9 +57,19 @@
       "allowedVersions": "3.x"
     },
     {
-      "description": "Add branch-specific label for master/v9.4",
+      "description": "Add branch-specific label for master/v9.5",
       "matchBaseBranches": [
         "master"
+      ],
+      "labels": [
+        "dependencies",
+        "v9.5"
+      ]
+    },
+    {
+      "description": "Add branch-specific label for v9.4",
+      "matchBaseBranches": [
+        "v9.4"
       ],
       "labels": [
         "dependencies",
@@ -70,33 +77,13 @@
       ]
     },
     {
-      "description": "Add branch-specific label for v9.2",
+      "description": "Add branch-specific label for v9.3",
       "matchBaseBranches": [
         "v9.3"
       ],
       "labels": [
         "dependencies",
         "v9.3"
-      ]
-    },
-    {
-      "description": "Add branch-specific label for v9.2",
-      "matchBaseBranches": [
-        "v9.2"
-      ],
-      "labels": [
-        "dependencies",
-        "v9.2"
-      ]
-    },
-    {
-      "description": "Add branch-specific label for v9.1",
-      "matchBaseBranches": [
-        "v9.1"
-      ],
-      "labels": [
-        "dependencies",
-        "v9.1"
       ]
     },
     {
@@ -107,16 +94,6 @@
       "labels": [
         "dependencies",
         "v8.19"
-      ]
-    },
-    {
-      "description": "Add branch-specific label for v8.18",
-      "matchBaseBranches": [
-        "v8.18"
-      ],
-      "labels": [
-        "dependencies",
-        "v8.18"
       ]
     }
   ]


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v9.3`:
 - [[skip-ci] Deprecate 9.2 branch (#3560)](https://github.com/elastic/ems-landing-page/pull/3560)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)