### PR TITLE
chore(deps): bump resolutions to current patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "whatwg-fetch": "3.6.20"
   },
   "resolutions": {
-    "**/yaml": "^2.8.0",
-    "**/semver": "^7.7.2",
-    "**/@babel/runtime": "^7.26.10",
+    "**/yaml": "^2.8.4",
+    "**/semver": "^7.7.4",
+    "**/@babel/runtime": "^7.29.2",
     "**/protocol-buffers-schema": "^3.6.1"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,7 +69,7 @@
   dependencies:
     "@babel/types" "^7.25.9"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.24.1", "@babel/runtime@^7.26.10", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.24.1", "@babel/runtime@^7.29.2", "@babel/runtime@^7.9.2":
   version "7.29.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
   integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
@@ -3937,10 +3937,10 @@ scheduler@^0.23.2:
   dependencies:
     loose-envify "^1.1.0"
 
-semver@7.7.4, semver@^6.3.1, semver@^7.7.2:
-  version "7.7.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
-  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+semver@7.7.4, semver@^6.3.1, semver@^7.7.4:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
 set-function-length@^1.2.1, set-function-length@^1.2.2:
   version "1.2.2"
@@ -4752,10 +4752,10 @@ xtend@^4.0.0, xtend@^4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-yaml@^1.10.0, yaml@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.0.tgz#15f8c9866211bdc2d3781a0890e44d4fa1a5fff6"
-  integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==
+yaml@^1.10.0, yaml@^2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.4.tgz#4b5f411dd25f9544914d8673d4da7f29248e5e2e"
+  integrity sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary
- Bump `yaml` resolution `^2.8.0` → `^2.8.4`
- Bump `semver` resolution `^7.7.2` → `^7.7.4`
- Bump `@babel/runtime` resolution `^7.26.10` → `^7.29.2`
- `protocol-buffers-schema` kept at `^3.6.1` (CVE-2026-5758)

Audit found three of four resolutions lagged behind current patch releases. `@babel/runtime` was already resolving to `7.29.2` via natural deps, so the pin bump aligns the constraint with reality. No major-version changes; risk surface unchanged.

## Test plan
- [x] `yarn install` succeeds
- [x] `yarn lint` passes
- [x] `yarn compile` builds
- [x] `yarn test` — 7/7 Playwright tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)