### PR TITLE
[v9.4] chore(deps): update dependency @babel/runtime to v8 (master) (#3642)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "resolutions": {
     "**/yaml": "^2.8.4",
     "**/semver": "^7.7.4",
-    "**/@babel/runtime": "^7.29.2",
+    "**/@babel/runtime": "^8.0.0",
     "**/protocol-buffers-schema": "^3.6.1",
     "**/brace-expansion": "^5.0.6"
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,12 +14,20 @@ export default defineConfig({
 
   // Polyfill Node built-ins needed by @elastic/ems-client and deps (e.g. lru-cache uses util)
   resolve: {
-    alias: {
-      buffer: 'buffer',
-      process: 'process/browser.js',
-      url: 'url',
-      util: 'util',
-    },
+    alias: [
+      { find: 'buffer', replacement: 'buffer' },
+      { find: 'process', replacement: 'process/browser.js' },
+      { find: 'url', replacement: 'url' },
+      { find: 'util', replacement: 'util' },
+      // @babel/runtime v8 dropped the public "helpers/esm/*" subpath from its
+      // exports map, but several deps (emotion, react-redux, react-focus-lock,
+      // react-window, redux, ...) still deep-import that path from their
+      // precompiled ESM output. Resolve straight to the file on disk.
+      {
+        find: /^@babel\/runtime\/helpers\/esm\/(.+)$/,
+        replacement: resolve(__dirname, 'node_modules/@babel/runtime/helpers/esm/$1.js'),
+      },
+    ],
   },
   // Set base path from environment variable (for CDN deployments)
   base: process.env.ASSET_PATH || '/',

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,10 +69,10 @@
   dependencies:
     "@babel/types" "^7.25.9"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.24.1", "@babel/runtime@^7.29.2", "@babel/runtime@^7.9.2":
-  version "7.29.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
-  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.24.1", "@babel/runtime@^7.9.2", "@babel/runtime@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-8.0.0.tgz#d7bd513e6843662346552c2798ab895716cf97f2"
+  integrity sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw==
 
 "@babel/template@^7.25.9":
   version "7.25.9"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v9.4`:
 - [chore(deps): update dependency @babel/runtime to v8 (master) (#3642)](https://github.com/elastic/ems-landing-page/pull/3642)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)