### PR TITLE
chore: bump version to 9.6

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,12 +3,13 @@
   "repoName": "ems-landing-page",
   "targetBranchChoices": [
     "master",
+    "v9.5",
     "v9.4",
     "v9.3",
     "v8.19"
   ],
   "branchLabelMapping": {
-    "^v9.5$": "master",
+    "^v9.6$": "master",
     "^v(\\d+).(\\d+)$": "v$1.$2"
   },
   "targetPRLabels": ["backport"],

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,6 +8,7 @@ on:
       - v9.3
       - v9.4
       - v9.5
+      - v9.6
 
 jobs:
   backport:

--- a/.github/workflows/sync_9.yml
+++ b/.github/workflows/sync_9.yml
@@ -1,4 +1,4 @@
-name: Sync master with v9.5
+name: Sync master with v9.6
 on:
   push:
     branches:
@@ -21,4 +21,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "master"
-          TO_BRANCH: "v9.5"
+          TO_BRANCH: "v9.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ems_landing_page",
-  "version": "9.5.0",
+  "version": "9.6.0",
   "description": "",
   "main": "main.js",
   "type": "module",

--- a/public/config.json
+++ b/public/config.json
@@ -2,7 +2,7 @@
   "default": "production",
   "serviceName": "Elastic Maps Service",
   "SUPPORTED_EMS": {
-    "emsVersion": "9.5.0",
+    "emsVersion": "9.6.0",
     "manifest": {
       "testing": {
         "emsFileApiUrl": "https://storage.googleapis.com/elastic-bekitzur-emsfiles-vector-dev",

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   ],
   "baseBranchPatterns": [
     "master",
+    "v9.5",
     "v9.4",
     "v9.3",
     "v8.19"
@@ -57,9 +58,19 @@
       "allowedVersions": "3.x"
     },
     {
-      "description": "Add branch-specific label for master/v9.5",
+      "description": "Add branch-specific label for master/v9.6",
       "matchBaseBranches": [
         "master"
+      ],
+      "labels": [
+        "dependencies",
+        "v9.6"
+      ]
+    },
+    {
+      "description": "Add branch-specific label for v9.5",
+      "matchBaseBranches": [
+        "v9.5"
       ],
       "labels": [
         "dependencies",


### PR DESCRIPTION
## Summary

- Bumps `package.json` and `public/config.json` version from `9.5.0` to `9.6.0`
- Adds `v9.5` to backport target branches and renovate base branches
- Updates `sync_9.yml` workflow to sync master → `v9.6`
- Updates `backport.yml` to ignore `v9.6` branch
- Updates `renovate.json` labels for master/v9.6 and adds v9.5 branch label rule

Follows the same pattern as #3385 (9.4 → 9.5 bump).

## Test plan

- [x] `yarn build-unsafe` passes (lint + webpack)
- [x] `yarn test` — Playwright tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)