### PR TITLE
fix(build): strip tag date suffix from ASSET_PATH

### DIFF
--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -23,8 +23,13 @@ else
   echo "Using 🌠 Borealis 🌠 theme"
 fi
 
-if [[ "${BUILDKITE_BRANCH}" != "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]] ; then
-  export ASSET_PATH="/${BUILDKITE_BRANCH}/"
+# On tag builds BUILDKITE_BRANCH is the tag itself (e.g. "v9.5-2026-07-13"),
+# not the plain branch name. Strip the date suffix so ASSET_PATH matches the
+# directory upload.sh actually deploys to (see BRANCH in upload.sh).
+BRANCH_NAME=$(echo "${BUILDKITE_BRANCH}" | cut -d "-" -f 1)
+
+if [[ "${BRANCH_NAME}" != "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]] ; then
+  export ASSET_PATH="/${BRANCH_NAME}/"
   echo "Asset base path: ${ASSET_PATH}"
 fi
 


### PR DESCRIPTION
## Summary

- Production tag builds set `BUILDKITE_BRANCH` to the full tag ref (e.g.
  `v9.5-2026-07-13`), not the plain branch name. `build.sh` baked that raw
  value into `ASSET_PATH`, so Vite embedded asset URLs like
  `/v9.5-2026-07-13/assets/*`.
- `upload.sh` already strips the date suffix (`cut -d "-" -f 1`) to compute
  its `gsutil` destination (`/v9.5/`), so the built HTML and the deployed
  assets ended up in different directories — 404s on production
  (confirmed on the live `v9.5` deploy, build
  https://buildkite.com/elastic/ems-landing-page/builds/8983).
- Strip the date suffix in `build.sh` the same way, so `ASSET_PATH` matches
  where `upload.sh` actually deploys.

## Test plan

- [ ] `yarn build-unsafe` passes
- [ ] verify next `master` and versioned-branch tag deploys resolve assets
      correctly in staging/production