### PR TITLE
fix(build): use relative ASSET_PATH for versioned deploy builds

### DIFF
--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -24,12 +24,15 @@ else
 fi
 
 # On tag builds BUILDKITE_BRANCH is the tag itself (e.g. "v9.5-2026-07-13"),
-# not the plain branch name. Strip the date suffix so ASSET_PATH matches the
-# directory upload.sh actually deploys to (see BRANCH in upload.sh).
+# not the plain branch name, so an absolute ASSET_PATH derived from it can
+# mismatch the directory upload.sh deploys to. Use a relative base instead:
+# it resolves correctly against whatever path the build ends up served from,
+# regardless of branch/tag naming. Default (unset ASSET_PATH) branch builds
+# are untouched, since other consumers rely on vite's default absolute base.
 BRANCH_NAME=$(echo "${BUILDKITE_BRANCH}" | cut -d "-" -f 1)
 
 if [[ "${BRANCH_NAME}" != "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]] ; then
-  export ASSET_PATH="/${BRANCH_NAME}/"
+  export ASSET_PATH="./"
   echo "Asset base path: ${ASSET_PATH}"
 fi
 


### PR DESCRIPTION
## Summary
- Absolute `ASSET_PATH` derived from `BUILDKITE_BRANCH` is brittle across branch/tag naming — tag builds append a date suffix (e.g. `v9.5-2026-07-13`), which required extra stripping logic (#3710) to keep it matching upload.sh's deploy directory.
- Switches versioned deploy builds to a relative base (`ASSET_PATH="./"`) instead, which resolves correctly against whatever path the build is served from, regardless of branch/tag naming.
- Default branch builds (where `ASSET_PATH` is left unset) are untouched — other products embedding this build with vite's default absolute base (`/`) keep their current behavior.

## Test plan
- [ ] CI build/e2e pass
- [ ] Deploy to staging, verify asset refs in built `index.html` are relative and resolve correctly under the versioned path
- [ ] Spot-check that master/default-branch build output is unchanged (absolute base)

🤖 Generated with [Claude Code](https://claude.com/claude-code)