### PR TITLE
fix(ci): deploy steps wait for e2e-test to complete

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,7 +31,9 @@ steps:
   - key: deploy-staging
     label: ":rocket: Stage"
     if: build.tag == null && ( build.branch == "master"  || build.branch =~ /^v\d{1,2}\.\d{1,2}$$/ )
-    depends_on: build
+    depends_on:
+      - build
+      - e2e-test
     command: ".buildkite/scripts/upload.sh"
     env:
       EMS_ENVIRONMENT: "staging"
@@ -39,7 +41,9 @@ steps:
   - key: should-deploy
     block: ":one-does-not-simply: Deploy"
     if: build.tag =~ /(master|v\d{1,2}\.\d{1,2})-\d{4}-\d{2}-\d{2}/
-    depends_on: build
+    depends_on:
+      - build
+      - e2e-test
 
   - key: deploy-production
     label: ":shipit: Deploy"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,24 @@ Deploy the changes to production by doing the following steps per each affected 
 1. Push it to the Elastic remote `git push --tags`
 1. A new deploy job will be triggered in Buildkite with a blocking step that needs to be accepted by a member of the team
 1. Wait for the job to finish and review the changes in production at <https://maps.elastic.co>` or `https://maps.elastic.co/{some-release-branch}/` (ex. [7.2](https://maps.elastic.co/v7.2))
+1. If the site is not yet updated, the CDN cache may need manual invalidation. This applies to all deployed branch paths, including `master` (root) and versioned branches (e.g. `/v9.5/`).
+
+    Invalidate a specific branch:
+    ```bash
+    BRANCH=v9.5  # or master
+    gcloud compute url-maps invalidate-cdn-cache elastic-apps-ems-prod \
+      --path "/${BRANCH}/*" \
+      --project elastic-ems-prod \
+      --global
+    ```
+
+    Invalidate everything (root + all branches):
+    ```bash
+    gcloud compute url-maps invalidate-cdn-cache elastic-apps-ems-prod \
+      --path "/*" \
+      --project elastic-ems-prod \
+      --global
+    ```
 
 **Note**: The Buildkite deploy job does not take any assets from staging. It builds all the assets from the source code and syncs with the production bucket, removing old assets if necessary.
 


### PR DESCRIPTION
## Summary

- `deploy-staging` and `should-deploy` had `depends_on: build` only
- Explicit `depends_on` bypasses Buildkite's positional `wait` step
- Deploy could start while E2E tests were still running
- Documents CDN cache invalidation: all `maps.elastic.co` paths are CDN-fronted; after a deploy replaces asset hashes, stale `index.html` can cause JS bundle 404s for up to 1h

## Changes

- `.buildkite/pipeline.yml`: add `e2e-test` to `depends_on` for `deploy-staging` and `should-deploy`
- `CONTRIBUTING.md`: add `gcloud` CDN invalidation snippets for per-branch and full invalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)