### PR TITLE
[skip-ci] Deprecate 9.3 branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -5,7 +5,6 @@
     "master",
     "v9.5",
     "v9.4",
-    "v9.3",
     "v8.19"
   ],
   "branchLabelMapping": {

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,7 +5,6 @@ on:
     types: ["labeled", "closed"]
     branches-ignore:
       - v8.19
-      - v9.3
       - v9.4
       - v9.5
       - v9.6

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,6 @@
     "master",
     "v9.5",
     "v9.4",
-    "v9.3",
     "v8.19"
   ],
   "labels": [
@@ -85,16 +84,6 @@
       "labels": [
         "dependencies",
         "v9.4"
-      ]
-    },
-    {
-      "description": "Add branch-specific label for v9.3",
-      "matchBaseBranches": [
-        "v9.3"
-      ],
-      "labels": [
-        "dependencies",
-        "v9.3"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- Removes `v9.3` from backport target branches, the backport workflow `branches-ignore` list, and Renovate `baseBranchPatterns` plus the v9.3-specific label rule.
- Mirrors #3560 (which deprecated `v9.2`) on the same three files.

## Test plan

- [ ] Renovate dashboard no longer enumerates v9.3 base branch
- [ ] Backport label flow ignores merges to v9.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)