### PR TITLE
[v9.5] [skip-ci] Deprecate 9.3 branch (#3803)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -4,7 +4,6 @@
   "targetBranchChoices": [
     "master",
     "v9.4",
-    "v9.3",
     "v8.19"
   ],
   "branchLabelMapping": {

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,11 +3,12 @@
   "repoName": "ems-landing-page",
   "targetBranchChoices": [
     "master",
+    "v9.5",
     "v9.4",
     "v8.19"
   ],
   "branchLabelMapping": {
-    "^v9.5$": "master",
+    "^v9.6$": "master",
     "^v(\\d+).(\\d+)$": "v$1.$2"
   },
   "targetPRLabels": ["backport"],

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,6 +7,7 @@ on:
       - v8.19
       - v9.4
       - v9.5
+      - v9.6
 
 jobs:
   backport:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,7 +5,6 @@ on:
     types: ["labeled", "closed"]
     branches-ignore:
       - v8.19
-      - v9.3
       - v9.4
       - v9.5
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
   "baseBranchPatterns": [
     "master",
     "v9.4",
-    "v9.3",
     "v8.19"
   ],
   "labels": [
@@ -74,16 +73,6 @@
       "labels": [
         "dependencies",
         "v9.4"
-      ]
-    },
-    {
-      "description": "Add branch-specific label for v9.3",
-      "matchBaseBranches": [
-        "v9.3"
-      ],
-      "labels": [
-        "dependencies",
-        "v9.3"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   ],
   "baseBranchPatterns": [
     "master",
+    "v9.5",
     "v9.4",
     "v8.19"
   ],
@@ -56,9 +57,19 @@
       "allowedVersions": "3.x"
     },
     {
-      "description": "Add branch-specific label for master/v9.5",
+      "description": "Add branch-specific label for master/v9.6",
       "matchBaseBranches": [
         "master"
+      ],
+      "labels": [
+        "dependencies",
+        "v9.6"
+      ]
+    },
+    {
+      "description": "Add branch-specific label for v9.5",
+      "matchBaseBranches": [
+        "v9.5"
       ],
       "labels": [
         "dependencies",


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v9.5`:
 - [[skip-ci] Deprecate 9.3 branch (#3803)](https://github.com/elastic/ems-landing-page/pull/3803)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)