### PR TITLE
[v9.4] [skip-ci] Deprecate 9.3 branch (#3803)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,11 +3,12 @@
   "repoName": "ems-landing-page",
   "targetBranchChoices": [
     "master",
-    "v9.3",
+    "v9.5",
+    "v9.4",
     "v8.19"
   ],
   "branchLabelMapping": {
-    "^v9.4$": "master",
+    "^v9.6$": "master",
     "^v(\\d+).(\\d+)$": "v$1.$2"
   },
   "targetPRLabels": ["backport"],

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,8 +5,9 @@ on:
     types: ["labeled", "closed"]
     branches-ignore:
       - v8.19
-      - v9.3
       - v9.4
+      - v9.5
+      - v9.6
 
 jobs:
   backport:

--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,10 @@
   "extends": [
     "github>elastic/renovate-config"
   ],
-  "baseBranches": [
+  "baseBranchPatterns": [
     "master",
-    "v9.3",
+    "v9.5",
+    "v9.4",
     "v8.19"
   ],
   "labels": [
@@ -56,23 +57,33 @@
       "allowedVersions": "3.x"
     },
     {
-      "description": "Add branch-specific label for master/v9.4",
+      "description": "Add branch-specific label for master/v9.6",
       "matchBaseBranches": [
         "master"
       ],
       "labels": [
         "dependencies",
-        "v9.4"
+        "v9.6"
       ]
     },
     {
-      "description": "Add branch-specific label for v9.2",
+      "description": "Add branch-specific label for v9.5",
       "matchBaseBranches": [
-        "v9.3"
+        "v9.5"
       ],
       "labels": [
         "dependencies",
-        "v9.3"
+        "v9.5"
+      ]
+    },
+    {
+      "description": "Add branch-specific label for v9.4",
+      "matchBaseBranches": [
+        "v9.4"
+      ],
+      "labels": [
+        "dependencies",
+        "v9.4"
       ]
     },
     {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v9.4`:
 - [[skip-ci] Deprecate 9.3 branch (#3803)](https://github.com/elastic/ems-landing-page/pull/3803)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)