### PR TITLE
fix(ci): grant write permissions to sync_9 and backport workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,6 +14,10 @@ jobs:
     name: Backport PR
     if: github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Backport Action
         uses: sorenlouv/backport-github-action@8a6c0381851f43f9f1fddc7303f0e9015eb57b62 # v12.0.4

--- a/.github/workflows/sync_9.yml
+++ b/.github/workflows/sync_9.yml
@@ -8,6 +8,9 @@ jobs:
   sync-branches:
     runs-on: ubuntu-latest
     name: Syncing branches
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7


### PR DESCRIPTION
## Problem
Two workflows have been silently failing with `403 Resource not accessible by integration` since 2026-08-03:

1. `.github/workflows/sync_9.yml` (master → v9.6 sync) — fails on every push to master.
2. `.github/workflows/backport.yml` (automatic backport action) — failed backporting PR #3803 (run [30908550183](https://github.com/elastic/ems-landing-page/actions/runs/30908550183)): `remote: Permission ... denied to github-actions[bot]` pushing backport branches, then `Resource not accessible by integration` posting the failure status comment. #3804/#3805/#3806 exist only because the backport was re-run manually via the `backport` CLI afterward.

## Root cause
Repo setting `Settings > Actions > General > Workflow permissions` is **read-only** by default (confirmed via `GET /repos/elastic/ems-landing-page/actions/permissions/workflow` → `default_workflow_permissions: read`). Neither workflow declared an explicit `permissions:` block, so `github-actions[bot]` only ever got a read-only token.

## Fix
Add explicit `permissions:` blocks scoped to what each job actually does:

- `sync_9.yml`: `pull-requests: write` (tretuna/sync-branches only opens a PR between two existing branches, no push).
- `backport.yml`: `contents: write` (push backport branches) + `pull-requests: write` (open backport PRs, and this repo's `.backportrc.json` has `autoMerge: true`) + `issues: write` (post status comments on the source PR).

## Verification
Not run live — merging will be verified by the next push to master (sync_9) and next merged PR (backport action) actually succeeding instead of 403ing.

## Out of scope
Each non-master branch (v8.19, v9.4, v9.5, v9.6) carries its own stale, differently-targeted copy of `sync_9.yml` (e.g. v8.19's still points `TO_BRANCH: "v9.1"`). These never execute — push-triggered workflows only run from the pushed-to ref's own tree — so no backport of this fix is needed, but they're dead code worth deleting separately.