### PR TITLE
chore(renovate): group react library updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,15 @@
       "minimumReleaseAge": "3 days"
     },
     {
+      "groupName": "React",
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "/^react-/",
+        "/^@types/react/"
+      ]
+    },
+    {
       "description": "Pin EUI to 107.x for v8 branches",
       "matchBaseBranches": [
         "v8.19"


### PR DESCRIPTION
## Summary
Adds a new Renovate `packageRules` group, **React**, so `react`, `react-dom`, and any other `react-*` / `@types/react*` packages get bundled into a single update PR instead of separate ones per package.

## Details
- Matches: `react`, `react-dom`, `/^react-/` (e.g. `react-router`, `react-redux`), `/^@types/react/` (e.g. `@types/react`, `@types/react-dom`)
- Follows the same pattern already used for the existing `Elastic EUI` group.

## Test
- Validated `renovate.json` with `jq` (valid JSON).