### PR TITLE
chore(renovate): pin react/react-dom below v19

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,14 @@
       ]
     },
     {
+      "description": "Pin React to <19 until @elastic/eui supports React 19",
+      "matchPackageNames": [
+        "react",
+        "react-dom"
+      ],
+      "allowedVersions": "<19.0.0"
+    },
+    {
       "description": "Pin EUI to 107.x for v8 branches",
       "matchBaseBranches": [
         "v8.19"


### PR DESCRIPTION
## Summary
`@elastic/eui` doesn't support React 19 yet. Caps `react`/`react-dom` so Renovate stops proposing major bumps to 19.x until EUI catches up.

## Details
- Adds `packageRules` entry: `matchPackageNames: ["react", "react-dom"]`, `allowedVersions: "<19.0.0"`.
- Mirrors the existing `Pin EUI to 107.x for v8 branches` pattern already in this file.
- 18.x minor/patch updates are unaffected (still covered by the existing `minor`/`patch` automerge rule).
- Follow-up to #3809 (React group) — closing PRs manually doesn't stick since Renovate recreates one per new 19.x release; this filters it before a PR is even opened.

## Test
- Validated `renovate.json` with `jq` (valid JSON).

## Follow-up
Once EUI ships React 19 support, remove or bump this rule's ceiling.